### PR TITLE
[#129] DevOps - Split Docker Dev Environments for Robotick

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -58,7 +58,6 @@
             "description": "Debug build for ESP32-S3 using Espressif toolchain and SDK",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
-                "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/toolchain-esp32s3.cmake",
                 "CMAKE_BUILD_TYPE": "Debug",
                 "ROBOTICK_PLATFORM_ESP32": "ON",
                 "ROBOTICK_BUILD_TESTS": "OFF"

--- a/docker-build-esp32s3.sh
+++ b/docker-build-esp32s3.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+docker build -t robotick-dev:esp32s3 -f robotick-engine/docker/Docker.esp32s3.dev .

--- a/docker-run-esp32s3.sh
+++ b/docker-run-esp32s3.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# Start ssh-agent if needed
+if [ -z "$SSH_AUTH_SOCK" ]; then
+    echo "🛑 SSH_AUTH_SOCK not set. Starting agent..."
+    eval "$(ssh-agent -s)"
+    ssh-add ~/.ssh/id_ed25519
+fi
+
+# Validate the socket
+if [ ! -S "$SSH_AUTH_SOCK" ]; then
+    echo "🛑 SSH agent socket not found at: $SSH_AUTH_SOCK"
+    exit 1
+fi
+
+# Clean up old container if needed
+if docker ps -a --format '{{.Names}}' | grep -q "^robotick-dev-esp32s3$"; then
+    echo "🧼 Removing existing container 'robotick-dev-esp32s3'..."
+    docker rm -f robotick-dev-esp32s3
+fi
+
+# 🚀 Run container with mounts and ssh agent
+docker run -it \
+  -v "$(pwd)":/workspace \
+  -v "$HOME/.robotick-vscode-server":/root/.vscode-server \
+  -v "$SSH_AUTH_SOCK:/ssh-agent" \
+  -e SSH_AUTH_SOCK=/ssh-agent \
+  --name robotick-dev-esp32s3 \
+  robotick-dev:esp32s3 \
+  bash

--- a/docker/Docker.esp32s3.dev
+++ b/docker/Docker.esp32s3.dev
@@ -1,4 +1,3 @@
-FROM espressif/idf:release-v5.1
+FROM espressif/idf:release-v5.4
 
-# Optional: Install Ninja, CMake, etc. (if needed)
-RUN apt-get update && apt-get install -y cmake ninja-build
+# Minimal, since the image already contains toolchains, Python env, and ESP-IDF


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scripts to automate building and running a Docker development environment for ESP32-S3, including SSH agent integration and workspace mounting.

- **Chores**
  - Updated the ESP32-S3 development Docker image to use a newer base version with pre-installed toolchains and components.
  - Simplified Dockerfile by removing redundant package installations.
  - Adjusted configuration presets for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->