### PR TITLE
Add incoming data-connection suppression for telemetry control

### DIFF
--- a/cpp/include/robotick/framework/Engine.h
+++ b/cpp/include/robotick/framework/Engine.h
@@ -15,6 +15,7 @@ namespace robotick
 	class TelemetryServer;
 	class WorkloadsBuffer;
 	struct DataConnectionInfo;
+	struct DataConnectionInputHandle;
 	struct StructDescriptor;
 	struct TickInfo;
 	struct WorkloadInstanceInfo;
@@ -53,6 +54,11 @@ namespace robotick
 		const Map<const char*, WorkloadInstanceInfo*>& get_all_instance_info_map() const;
 
 		const HeapVector<DataConnectionInfo>& get_all_data_connections() const;
+		DataConnectionInputHandle* find_data_connection_input_handle_by_path(const char* path) const;
+		DataConnectionInputHandle* find_data_connection_input_handle_by_dest_ptr(const void* dest_ptr) const;
+		DataConnectionInputHandle* find_data_connection_input_handle_by_handle_id(uint16_t handle_id) const;
+		DataConnectionInputHandle* find_data_connection_input_handle_by_overlap(const void* dest_ptr, size_t size) const;
+		DataConnectionInputHandle* find_or_create_data_connection_input_handle(const char* path, void* dest_ptr, size_t size, TypeId type);
 
 		WorkloadsBuffer& get_workloads_buffer() const;
 		TelemetryServer& get_telemetry_server() const;

--- a/cpp/include/robotick/framework/data/DataConnection.h
+++ b/cpp/include/robotick/framework/data/DataConnection.h
@@ -69,6 +69,19 @@ namespace robotick
 
 			::memcpy(static_cast<uint8_t*>(dest_ptr) + offset, src_ptr, bytes);
 		}
+
+		void do_copy_data_partial_unchecked(const void* src_ptr, size_t offset, size_t bytes) const noexcept
+		{
+			ROBOTICK_ASSERT(src_ptr != nullptr && dest_ptr != nullptr);
+			ROBOTICK_ASSERT(offset <= size);
+			ROBOTICK_ASSERT(bytes <= size - offset);
+			if (bytes == 0)
+			{
+				return;
+			}
+
+			::memcpy(static_cast<uint8_t*>(dest_ptr) + offset, src_ptr, bytes);
+		}
 	};
 
 	struct DataConnectionInfo

--- a/cpp/include/robotick/framework/data/DataConnection.h
+++ b/cpp/include/robotick/framework/data/DataConnection.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "robotick/api_base.h"
+#include "robotick/framework/concurrency/Atomic.h"
 #include "robotick/framework/containers/ArrayView.h"
 #include "robotick/framework/containers/HeapVector.h"
 #include "robotick/framework/containers/Map.h"
@@ -16,6 +17,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 
 namespace robotick
@@ -28,11 +30,53 @@ namespace robotick
 	struct TypeDescriptor;
 	class WorkloadsBuffer;
 
+	struct DataConnectionInputHandle
+	{
+		uint16_t handle_id = 0;
+		FixedString512 path;
+		void* dest_ptr = nullptr;
+		size_t size = 0;
+		TypeId type;
+		AtomicValue<uint8_t> enabled{1};
+
+		bool is_enabled() const noexcept { return enabled.load(std_approved::memory_order_acquire) != 0; }
+		void set_enabled(bool value) noexcept
+		{
+			enabled.store(value ? static_cast<uint8_t>(1) : static_cast<uint8_t>(0), std_approved::memory_order_release);
+		}
+
+		void do_copy_data(const void* src_ptr) const noexcept
+		{
+			ROBOTICK_ASSERT(src_ptr != nullptr && dest_ptr != nullptr && size > 0);
+			ROBOTICK_ASSERT(src_ptr != dest_ptr && "Source and destination pointers are the same - this should have been caught in fixup");
+			if (!is_enabled())
+			{
+				return;
+			}
+
+			::memcpy(dest_ptr, src_ptr, size);
+		}
+
+		void do_copy_data_partial(const void* src_ptr, size_t offset, size_t bytes) const noexcept
+		{
+			ROBOTICK_ASSERT(src_ptr != nullptr && dest_ptr != nullptr);
+			ROBOTICK_ASSERT(offset <= size);
+			ROBOTICK_ASSERT(bytes <= size - offset);
+			if (!is_enabled() || bytes == 0)
+			{
+				return;
+			}
+
+			::memcpy(static_cast<uint8_t*>(dest_ptr) + offset, src_ptr, bytes);
+		}
+	};
+
 	struct DataConnectionInfo
 	{
 		const DataConnectionSeed* seed = nullptr;
 		const void* source_ptr = nullptr;
 		void* dest_ptr = nullptr;
+		DataConnectionInputHandle* dest_handle = nullptr;
 		const WorkloadInstanceInfo* source_workload = nullptr;
 		const WorkloadInstanceInfo* dest_workload = nullptr;
 		size_t size = 0;
@@ -49,9 +93,14 @@ namespace robotick
 
 		void do_data_copy() const noexcept
 		{
+			if (dest_handle)
+			{
+				dest_handle->do_copy_data(source_ptr);
+				return;
+			}
+
 			ROBOTICK_ASSERT(source_ptr != nullptr && dest_ptr != nullptr && size > 0);
 			ROBOTICK_ASSERT(source_ptr != dest_ptr && "Source and destination pointers are the same - this should have been caught in fixup");
-
 			::memcpy(dest_ptr, source_ptr, size);
 		}
 	};

--- a/cpp/include/robotick/framework/data/RemoteEngineConnection.h
+++ b/cpp/include/robotick/framework/data/RemoteEngineConnection.h
@@ -14,6 +14,7 @@
 
 namespace robotick
 {
+	struct DataConnectionInputHandle;
 	struct TickInfo;
 	struct TypeDescriptor;
 
@@ -58,9 +59,9 @@ namespace robotick
 		{
 			FixedString512 path;
 			const void* send_ptr = nullptr;
-			void* recv_ptr = nullptr;
 			size_t size = 0;
 			const TypeDescriptor* type_desc = nullptr;
+			DataConnectionInputHandle* input_handle = nullptr;
 		};
 
 		using BinderCallback = Function<bool(const char* path, Field& out_field)>;

--- a/cpp/include/robotick/framework/data/RemoteEngineConnection.h
+++ b/cpp/include/robotick/framework/data/RemoteEngineConnection.h
@@ -187,6 +187,7 @@ namespace robotick
 			size_t field_index = 0;
 			size_t offset_in_field = 0;
 			size_t total_bytes_received = 0;
+			bool current_field_enabled = false;
 		} field_receive_state;
 
 		// Capture mutual tick-rate bytes from FieldsRequest across partial reads

--- a/cpp/src/robotick/framework/Engine.cpp
+++ b/cpp/src/robotick/framework/Engine.cpp
@@ -6,6 +6,7 @@
 #include "robotick/api.h"
 #include "robotick/framework/concurrency/Atomic.h"
 #include "robotick/framework/concurrency/Thread.h"
+#include "robotick/framework/containers/List.h"
 #include "robotick/framework/data/Blackboard.h"
 #include "robotick/framework/data/DataConnection.h"
 #include "robotick/framework/data/RemoteEngineConnections.h"
@@ -19,6 +20,7 @@
 #include "robotick/framework/utils/TypeId.h"
 
 #include <cstddef>
+#include <cstdint>
 
 namespace robotick
 {
@@ -36,6 +38,11 @@ namespace robotick
 		Map<const char*, WorkloadInstanceInfo*> instances_by_unique_name;
 		HeapVector<DataConnectionInfo> data_connections_all;
 		HeapVector<DataConnectionInfo*> data_connections_acquired;
+		List<DataConnectionInputHandle> data_connection_input_handles;
+		Map<const char*, DataConnectionInputHandle*, 128> data_connection_input_handles_by_path;
+		Map<uintptr_t, DataConnectionInputHandle*, 128> data_connection_input_handles_by_dest_ptr;
+		Map<uint16_t, DataConnectionInputHandle*, 128> data_connection_input_handles_by_id;
+		uint16_t next_data_connection_input_handle_id = 1;
 
 		RemoteEngineConnections remote_engine_connections;
 	};
@@ -288,6 +295,12 @@ namespace robotick
 		DataConnectionUtils::create(
 			state->data_connections_all, state->workloads_buffer, model.get_data_connection_seeds(), state->instances_by_unique_name);
 
+		for (DataConnectionInfo& conn : state->data_connections_all)
+		{
+			conn.dest_handle = find_or_create_data_connection_input_handle(
+				conn.seed ? conn.seed->dest_field_path.c_str() : nullptr, conn.dest_ptr, conn.size, conn.type);
+		}
+
 		const WorkloadInstanceInfo* root_instance = find_instance_info(model.get_root_workload()->unique_name.c_str());
 		ROBOTICK_ASSERT(root_instance != nullptr);
 
@@ -514,6 +527,109 @@ namespace robotick
 		return state->data_connections_all;
 	}
 
+	DataConnectionInputHandle* Engine::find_data_connection_input_handle_by_path(const char* path) const
+	{
+		if (!path)
+		{
+			return nullptr;
+		}
+		DataConnectionInputHandle** found = state->data_connection_input_handles_by_path.find(path);
+		return found ? *found : nullptr;
+	}
+
+	DataConnectionInputHandle* Engine::find_data_connection_input_handle_by_dest_ptr(const void* dest_ptr) const
+	{
+		if (!dest_ptr)
+		{
+			return nullptr;
+		}
+		DataConnectionInputHandle** found = state->data_connection_input_handles_by_dest_ptr.find(reinterpret_cast<uintptr_t>(dest_ptr));
+		return found ? *found : nullptr;
+	}
+
+	DataConnectionInputHandle* Engine::find_data_connection_input_handle_by_handle_id(uint16_t handle_id) const
+	{
+		if (handle_id == 0)
+		{
+			return nullptr;
+		}
+		DataConnectionInputHandle** found = state->data_connection_input_handles_by_id.find(handle_id);
+		return found ? *found : nullptr;
+	}
+
+	DataConnectionInputHandle* Engine::find_data_connection_input_handle_by_overlap(const void* dest_ptr, size_t size) const
+	{
+		if (!dest_ptr || size == 0)
+		{
+			return nullptr;
+		}
+
+		const uintptr_t target_begin = reinterpret_cast<uintptr_t>(dest_ptr);
+		const uintptr_t target_end = target_begin + size;
+		for (const DataConnectionInputHandle& handle : state->data_connection_input_handles)
+		{
+			if (!handle.dest_ptr || handle.size == 0)
+			{
+				continue;
+			}
+
+			const uintptr_t handle_begin = reinterpret_cast<uintptr_t>(handle.dest_ptr);
+			const uintptr_t handle_end = handle_begin + handle.size;
+			if (target_begin < handle_end && handle_begin < target_end)
+			{
+				return const_cast<DataConnectionInputHandle*>(&handle);
+			}
+		}
+
+		return nullptr;
+	}
+
+	DataConnectionInputHandle* Engine::find_or_create_data_connection_input_handle(const char* path, void* dest_ptr, size_t size, TypeId type)
+	{
+		if (!path || !dest_ptr || size == 0)
+		{
+			return nullptr;
+		}
+
+		if (DataConnectionInputHandle* existing_by_path = find_data_connection_input_handle_by_path(path))
+		{
+			ROBOTICK_ASSERT(existing_by_path->dest_ptr == dest_ptr);
+			ROBOTICK_ASSERT(existing_by_path->size == size);
+			ROBOTICK_ASSERT(existing_by_path->type == type);
+			return existing_by_path;
+		}
+
+		if (DataConnectionInputHandle* existing_by_ptr = find_data_connection_input_handle_by_dest_ptr(dest_ptr))
+		{
+			ROBOTICK_ASSERT(existing_by_ptr->size == size);
+			ROBOTICK_ASSERT(existing_by_ptr->type == type);
+			if (existing_by_ptr->path.empty())
+			{
+				existing_by_ptr->path = path;
+				state->data_connection_input_handles_by_path.insert(existing_by_ptr->path.c_str(), existing_by_ptr);
+			}
+			return existing_by_ptr;
+		}
+
+		if (state->next_data_connection_input_handle_id == 0)
+		{
+			ROBOTICK_FATAL_EXIT("DataConnectionInputHandle id overflow");
+		}
+
+		DataConnectionInputHandle& created = state->data_connection_input_handles.push_back();
+		created.handle_id = state->next_data_connection_input_handle_id++;
+		created.path = path;
+		created.dest_ptr = dest_ptr;
+		created.size = size;
+		created.type = type;
+		created.set_enabled(true);
+
+		state->data_connection_input_handles_by_path.insert(created.path.c_str(), &created);
+		state->data_connection_input_handles_by_dest_ptr.insert(reinterpret_cast<uintptr_t>(created.dest_ptr), &created);
+		state->data_connection_input_handles_by_id.insert(created.handle_id, &created);
+		return &created;
+	}
+
 	WorkloadsBuffer& Engine::get_workloads_buffer() const
 	{
 		return state->workloads_buffer;
@@ -662,6 +778,11 @@ namespace robotick
 		state->instances_by_unique_name.clear();
 		state->data_connections_all.reset();
 		state->data_connections_acquired.reset();
+		state->data_connection_input_handles.clear();
+		state->data_connection_input_handles_by_path.clear();
+		state->data_connection_input_handles_by_dest_ptr.clear();
+		state->data_connection_input_handles_by_id.clear();
+		state->next_data_connection_input_handle_id = 1;
 		state->instances.reset();
 		state->workloads_buffer = WorkloadsBuffer();
 	}

--- a/cpp/src/robotick/framework/data/DataConnection.cpp
+++ b/cpp/src/robotick/framework/data/DataConnection.cpp
@@ -298,8 +298,16 @@ namespace robotick
 			if (has_connection_to_field(out_connections, dst.ptr))
 				ROBOTICK_FATAL_EXIT("Duplicate connection to field: %s", seed.dest_field_path.c_str());
 
-			out_connections[connection_index] =
-				DataConnectionInfo{&seed, src.ptr, const_cast<void*>(dst.ptr), src.workload, dst.workload, src.size, src.type};
+			DataConnectionInfo resolved_connection;
+			resolved_connection.seed = &seed;
+			resolved_connection.source_ptr = src.ptr;
+			resolved_connection.dest_ptr = const_cast<void*>(dst.ptr);
+			resolved_connection.source_workload = src.workload;
+			resolved_connection.dest_workload = dst.workload;
+			resolved_connection.size = src.size;
+			resolved_connection.type = src.type;
+
+			out_connections[connection_index] = resolved_connection;
 
 			connection_index++;
 		}

--- a/cpp/src/robotick/framework/data/RemoteEngineConnection.cpp
+++ b/cpp/src/robotick/framework/data/RemoteEngineConnection.cpp
@@ -1295,10 +1295,14 @@ namespace robotick
 						field_receive_state.current_field_enabled = field.input_handle->is_enabled();
 					}
 
-					const size_t field_size = field.input_handle->size;
+					const size_t field_size = field.size;
+					if (field.input_handle->size != field_size)
+					{
+						ROBOTICK_FATAL_EXIT(
+							"Receiver field '%s' handle size mismatch (%zu != %zu)", field.path.c_str(), field.input_handle->size, field_size);
+					}
 					if (field.type_desc)
 					{
-						ROBOTICK_ASSERT(field.size == field.input_handle->size);
 						ROBOTICK_ASSERT(TypeRegistry::get().find_by_id(field.input_handle->type) == field.type_desc);
 					}
 

--- a/cpp/src/robotick/framework/data/RemoteEngineConnection.cpp
+++ b/cpp/src/robotick/framework/data/RemoteEngineConnection.cpp
@@ -4,6 +4,7 @@
 #include "robotick/framework/data/RemoteEngineConnection.h"
 #include "robotick/api.h"
 #include "robotick/framework/concurrency/Thread.h"
+#include "robotick/framework/data/DataConnection.h"
 #include "robotick/framework/math/IsFinite.h"
 
 #include <arpa/inet.h>
@@ -1284,21 +1285,28 @@ namespace robotick
 				while (cursor < len && field_receive_state.field_index < field_count)
 				{
 					auto& field = fields[field_receive_state.field_index];
-					if (!field.recv_ptr)
+					if (!field.input_handle)
 					{
-						ROBOTICK_FATAL_EXIT("Receiver field '%s' has null recv_ptr", field.path.c_str());
+						ROBOTICK_FATAL_EXIT("Receiver field '%s' has null input_handle", field.path.c_str());
 					}
 
-					const size_t remaining_in_field = field.size - field_receive_state.offset_in_field;
+					const size_t field_size = field.input_handle->size;
+					if (field.type_desc)
+					{
+						ROBOTICK_ASSERT(field.size == field.input_handle->size);
+						ROBOTICK_ASSERT(TypeRegistry::get().find_by_id(field.input_handle->type) == field.type_desc);
+					}
+
+					const size_t remaining_in_field = field_size - field_receive_state.offset_in_field;
 					const size_t take = rtk_min(remaining_in_field, len - cursor);
 
-					::memcpy(static_cast<uint8_t*>(field.recv_ptr) + field_receive_state.offset_in_field, data + cursor, take);
+					field.input_handle->do_copy_data_partial(data + cursor, field_receive_state.offset_in_field, take);
 
 					cursor += take;
 					field_receive_state.offset_in_field += take;
 					field_receive_state.total_bytes_received += take;
 
-					if (field_receive_state.offset_in_field == field.size)
+					if (field_receive_state.offset_in_field == field_size)
 					{
 						field_receive_state.field_index++;
 						field_receive_state.offset_in_field = 0;

--- a/cpp/src/robotick/framework/data/RemoteEngineConnection.cpp
+++ b/cpp/src/robotick/framework/data/RemoteEngineConnection.cpp
@@ -1290,6 +1290,11 @@ namespace robotick
 						ROBOTICK_FATAL_EXIT("Receiver field '%s' has null input_handle", field.path.c_str());
 					}
 
+					if (field_receive_state.offset_in_field == 0)
+					{
+						field_receive_state.current_field_enabled = field.input_handle->is_enabled();
+					}
+
 					const size_t field_size = field.input_handle->size;
 					if (field.type_desc)
 					{
@@ -1300,7 +1305,10 @@ namespace robotick
 					const size_t remaining_in_field = field_size - field_receive_state.offset_in_field;
 					const size_t take = rtk_min(remaining_in_field, len - cursor);
 
-					field.input_handle->do_copy_data_partial(data + cursor, field_receive_state.offset_in_field, take);
+					if (field_receive_state.current_field_enabled)
+					{
+						field.input_handle->do_copy_data_partial_unchecked(data + cursor, field_receive_state.offset_in_field, take);
+					}
 
 					cursor += take;
 					field_receive_state.offset_in_field += take;
@@ -1310,6 +1318,7 @@ namespace robotick
 					{
 						field_receive_state.field_index++;
 						field_receive_state.offset_in_field = 0;
+						field_receive_state.current_field_enabled = false;
 					}
 				}
 

--- a/cpp/src/robotick/framework/data/RemoteEngineConnections.cpp
+++ b/cpp/src/robotick/framework/data/RemoteEngineConnections.cpp
@@ -70,9 +70,8 @@ namespace robotick
 							ROBOTICK_FATAL_EXIT("[REC::receiver] Receiver field has no descriptor: %s", path);
 						}
 						out.path = path;
-						out.input_handle = engine ? engine->find_or_create_data_connection_input_handle(
-														path, field_info.ptr, field_info.size, field_info.descriptor->type_id)
-												  : nullptr;
+						out.input_handle = engine->find_or_create_data_connection_input_handle(
+							path, field_info.ptr, field_info.size, field_info.descriptor->type_id);
 						out.size = field_info.size;
 						out.type_desc = field_info.descriptor->find_type_descriptor();
 						ROBOTICK_ASSERT(out.type_desc != nullptr);

--- a/cpp/src/robotick/framework/data/RemoteEngineConnections.cpp
+++ b/cpp/src/robotick/framework/data/RemoteEngineConnections.cpp
@@ -65,12 +65,15 @@ namespace robotick
 						{
 							ROBOTICK_FATAL_EXIT("[REC::receiver] Receiver failed to bind field: %s", path);
 						}
+						if (!field_info.descriptor)
+						{
+							ROBOTICK_FATAL_EXIT("[REC::receiver] Receiver field has no descriptor: %s", path);
+						}
 						out.path = path;
 						out.input_handle = engine ? engine->find_or_create_data_connection_input_handle(
 														path, field_info.ptr, field_info.size, field_info.descriptor->type_id)
 												  : nullptr;
 						out.size = field_info.size;
-						ROBOTICK_ASSERT(field_info.descriptor != nullptr);
 						out.type_desc = field_info.descriptor->find_type_descriptor();
 						ROBOTICK_ASSERT(out.type_desc != nullptr);
 						ROBOTICK_ASSERT(out.input_handle != nullptr);

--- a/cpp/src/robotick/framework/data/RemoteEngineConnections.cpp
+++ b/cpp/src/robotick/framework/data/RemoteEngineConnections.cpp
@@ -66,11 +66,17 @@ namespace robotick
 							ROBOTICK_FATAL_EXIT("[REC::receiver] Receiver failed to bind field: %s", path);
 						}
 						out.path = path;
-						out.recv_ptr = field_info.ptr;
+						out.input_handle = engine ? engine->find_or_create_data_connection_input_handle(
+														path, field_info.ptr, field_info.size, field_info.descriptor->type_id)
+												  : nullptr;
 						out.size = field_info.size;
 						ROBOTICK_ASSERT(field_info.descriptor != nullptr);
 						out.type_desc = field_info.descriptor->find_type_descriptor();
 						ROBOTICK_ASSERT(out.type_desc != nullptr);
+						ROBOTICK_ASSERT(out.input_handle != nullptr);
+						ROBOTICK_ASSERT(out.input_handle->dest_ptr == field_info.ptr);
+						ROBOTICK_ASSERT(out.input_handle->size == out.size);
+						ROBOTICK_ASSERT(out.input_handle->type == field_info.descriptor->type_id);
 						return true;
 					});
 

--- a/cpp/src/robotick/framework/data/RemoteEngineConnections.cpp
+++ b/cpp/src/robotick/framework/data/RemoteEngineConnections.cpp
@@ -49,14 +49,14 @@ namespace robotick
 
 		discoverer_receiver.initialize_receiver(my_model_name, model.get_telemetry_port(), model.get_telemetry_is_gateway());
 		discoverer_receiver.set_on_incoming_connection_requested(
-			[this, &model](const char* source_model_id, uint16_t& rec_port_out)
+			[this, &model, log_verbose](const char* source_model_id, uint16_t& rec_port_out)
 			{
 				ROBOTICK_INFO_IF(log_verbose, "[REC::receiver] Incoming discovery request from model '%s'", source_model_id);
 				RemoteEngineConnection& conn = dynamic_receivers.push_back();
 				conn.configure_receiver(model.get_model_name());
 
 				conn.set_field_binder(
-					[this](const char* path, RemoteEngineConnection::Field& out)
+					[this, log_verbose](const char* path, RemoteEngineConnection::Field& out)
 					{
 						ROBOTICK_INFO_IF(log_verbose, "[REC::receiver] Binding field '%s'", path);
 

--- a/cpp/src/robotick/framework/data/TelemetryServer.cpp
+++ b/cpp/src/robotick/framework/data/TelemetryServer.cpp
@@ -1598,11 +1598,13 @@ namespace robotick
 		Thread ws_broadcast_thread;
 		uint32_t ws_last_local_frame_seq = 0;
 		HeapVector<uint32_t> ws_last_peer_frame_seq;
+		size_t last_known_writable_connection_handle_count = 0;
 		static constexpr uint32_t ws_heartbeat_interval_ms = 1000;
 		static constexpr uint32_t ws_broadcast_tick_ms = 10;
 
 		void rebuild_writable_input_registry();
-		void refresh_writable_input_connection_handles();
+		bool refresh_writable_input_connection_handles();
+		size_t count_writable_input_connection_handles() const;
 		int find_writable_input_index_by_handle(uint16_t handle) const;
 		int find_writable_input_index_by_path(const char* path) const;
 		int find_telemetry_peer_index_by_model_id(const char* model_id) const;
@@ -1621,6 +1623,7 @@ namespace robotick
 		bool handle_ws_message(const WsRoute& route, const WebSocketConnection& connection, const WebSocketMessage& message);
 		void build_write_response_json(const char* request_body, size_t request_size, int& out_status_code, json::StringSink& out_json);
 		void build_connection_state_response_json(const char* request_body, size_t request_size, int& out_status_code, json::StringSink& out_json);
+		void maybe_broadcast_local_layout_update();
 		void maybe_broadcast_local_frame(const Clock::time_point now);
 		void maybe_broadcast_peer_frames(const Clock::time_point now);
 		void maybe_send_heartbeats(const Clock::time_point now);
@@ -2358,7 +2361,13 @@ namespace robotick
 
 		if (client.route.is_local)
 		{
+			const bool refreshed = refresh_writable_input_connection_handles();
+			last_known_writable_connection_handle_count = count_writable_input_connection_handles();
 #if defined(ROBOTICK_PLATFORM_ESP32S3)
+			if (refreshed)
+			{
+				rebuild_layout_cache();
+			}
 			LockGuard lock(layout_cache_mutex);
 			if (!has_cached_layout_body)
 			{
@@ -2370,6 +2379,7 @@ namespace robotick
 				unregister_ws_client(client.connection);
 			}
 #else
+			(void)refreshed;
 			json::StringSink layout_sink;
 			json::Writer<json::StringSink> writer(layout_sink);
 			write_layout_json_stream(writer, *engine, session_id.c_str(), writable_input_fields);
@@ -2525,10 +2535,51 @@ namespace robotick
 		while (!ws_broadcast_stop.is_set())
 		{
 			const Clock::time_point now = Clock::now();
+			maybe_broadcast_local_layout_update();
 			maybe_broadcast_local_frame(now);
 			maybe_broadcast_peer_frames(now);
 			maybe_send_heartbeats(now);
 			Thread::sleep_ms(ws_broadcast_tick_ms);
+		}
+	}
+
+	void TelemetryServer::Impl::maybe_broadcast_local_layout_update()
+	{
+		if (!engine)
+		{
+			return;
+		}
+
+		const bool refreshed = refresh_writable_input_connection_handles();
+		const size_t current_count = count_writable_input_connection_handles();
+		if (!refreshed && current_count == last_known_writable_connection_handle_count)
+		{
+			return;
+		}
+
+		last_known_writable_connection_handle_count = current_count;
+
+#if defined(ROBOTICK_PLATFORM_ESP32S3)
+		rebuild_layout_cache();
+#endif
+
+		FixedVector<WsClient, ws_max_clients> clients;
+		{
+			LockGuard lock(ws_clients_mutex);
+			for (size_t i = 0; i < ws_clients.size(); ++i)
+			{
+				const WsClient& client = ws_clients[i];
+				if (!client.active || !client.ready || !client.route.is_local)
+				{
+					continue;
+				}
+				clients.add(client);
+			}
+		}
+
+		for (size_t i = 0; i < clients.size(); ++i)
+		{
+			send_ws_layout(clients[i]);
 		}
 	}
 
@@ -3196,15 +3247,31 @@ namespace robotick
 				pending_input_writes[write_index] = PendingInputWrite{};
 				++write_index;
 			});
+
+		last_known_writable_connection_handle_count = count_writable_input_connection_handles();
 	}
 
-	void TelemetryServer::Impl::refresh_writable_input_connection_handles()
+	size_t TelemetryServer::Impl::count_writable_input_connection_handles() const
+	{
+		size_t count = 0;
+		for (size_t i = 0; i < writable_input_fields.size(); ++i)
+		{
+			if (writable_input_fields[i].incoming_connection_handle)
+			{
+				++count;
+			}
+		}
+		return count;
+	}
+
+	bool TelemetryServer::Impl::refresh_writable_input_connection_handles()
 	{
 		if (!engine)
 		{
-			return;
+			return false;
 		}
 
+		bool changed = false;
 		for (size_t i = 0; i < writable_input_fields.size(); ++i)
 		{
 			WritableInputField& writable = writable_input_fields[i];
@@ -3218,8 +3285,14 @@ namespace robotick
 			{
 				input_handle = engine->find_data_connection_input_handle_by_overlap(writable.target_ptr, writable.value_size);
 			}
-			writable.incoming_connection_handle = input_handle;
+			if (writable.incoming_connection_handle != input_handle)
+			{
+				writable.incoming_connection_handle = input_handle;
+				changed = true;
+			}
 		}
+
+		return changed;
 	}
 
 	void TelemetryServer::Impl::build_write_response_json(
@@ -4024,6 +4097,11 @@ namespace robotick
 		res.set_content_type("application/json");
 
 #if defined(ROBOTICK_PLATFORM_ESP32S3)
+		if (refresh_writable_input_connection_handles())
+		{
+			last_known_writable_connection_handle_count = count_writable_input_connection_handles();
+			rebuild_layout_cache();
+		}
 		LockGuard lock(layout_cache_mutex);
 		if (!has_cached_layout_body)
 		{
@@ -4043,6 +4121,7 @@ namespace robotick
 		res.set_body(cached_layout_body, cached_layout_body_size);
 #else
 		refresh_writable_input_connection_handles();
+		last_known_writable_connection_handle_count = count_writable_input_connection_handles();
 		json::StringSink sink;
 		json::Writer<json::StringSink> writer(sink);
 		write_layout_json_stream(writer, *engine, session_id.c_str(), writable_input_fields);

--- a/cpp/src/robotick/framework/data/TelemetryServer.cpp
+++ b/cpp/src/robotick/framework/data/TelemetryServer.cpp
@@ -3761,6 +3761,102 @@ namespace robotick
 		return type_name;
 	}
 
+	static bool type_name_requires_instance_shape(const TypeDescriptor& type_desc, void* data_ptr, uint32_t depth = 0)
+	{
+		if (depth > 16)
+		{
+			return false;
+		}
+
+		if (type_desc.get_dynamic_struct_desc())
+		{
+			return true;
+		}
+
+		const StructDescriptor* struct_desc = type_desc.get_struct_desc();
+		if (!struct_desc)
+		{
+			return false;
+		}
+
+		for (const FieldDescriptor& field : struct_desc->fields)
+		{
+			const TypeDescriptor* field_type = field.find_type_descriptor();
+			if (!field_type)
+			{
+				continue;
+			}
+
+			if (field_type->get_dynamic_struct_desc())
+			{
+				return true;
+			}
+
+			if (field_type->get_struct_desc())
+			{
+				void* field_data_ptr = field.get_data_ptr(data_ptr);
+				if (type_name_requires_instance_shape(*field_type, field_data_ptr, depth + 1))
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	static void update_instance_type_hash(Hash32& hash, const TypeDescriptor& type_desc, void* data_ptr, uint32_t depth = 0)
+	{
+		if (depth > 16)
+		{
+			return;
+		}
+
+		hash.update_cstring(type_desc.name.c_str());
+		hash.update(type_desc.id.value);
+		hash.update(type_desc.size);
+		hash.update(static_cast<uint32_t>(type_desc.type_category));
+
+		const DynamicStructDescriptor* dynamic_struct_desc = type_desc.get_dynamic_struct_desc();
+		const StructDescriptor* struct_desc =
+			dynamic_struct_desc ? dynamic_struct_desc->get_struct_descriptor(data_ptr) : type_desc.get_struct_desc();
+		if (!struct_desc)
+		{
+			return;
+		}
+
+		for (const FieldDescriptor& field : struct_desc->fields)
+		{
+			hash.update_cstring(field.name.c_str());
+			hash.update(field.type_id.value);
+			hash.update(field.offset_within_container);
+			hash.update(field.element_count);
+
+			const TypeDescriptor* field_type = field.find_type_descriptor();
+			if (!field_type)
+			{
+				continue;
+			}
+
+			void* field_data_ptr = field.get_data_ptr(data_ptr);
+			if (field_type->get_dynamic_struct_desc() || field_type->get_struct_desc())
+			{
+				update_instance_type_hash(hash, *field_type, field_data_ptr, depth + 1);
+			}
+		}
+	}
+
+	static FixedString64 make_instance_struct_type_name(const TypeDescriptor& type_desc, void* data_ptr)
+	{
+		robotick::Hash32 hash;
+		update_instance_type_hash(hash, type_desc, data_ptr);
+
+		FixedString64 type_name;
+		const char* base_name = type_desc.name.empty() ? "Struct" : type_desc.name.c_str();
+		type_name.format("%s_%08X", base_name, static_cast<unsigned int>(hash.final()));
+		return type_name;
+	}
+
 	static FixedString256 get_type_name(const TypeDescriptor& type_desc, void* data_ptr)
 	{
 		const DynamicStructDescriptor* dynamic_struct_desc = type_desc.get_dynamic_struct_desc();
@@ -3769,6 +3865,14 @@ namespace robotick
 			const FixedString64 blackboard_name = make_dynamic_struct_type_name(type_desc, *dynamic_struct_desc, data_ptr);
 			FixedString256 type_name;
 			type_name = blackboard_name.c_str();
+			return type_name;
+		}
+
+		if (type_desc.get_struct_desc() && type_name_requires_instance_shape(type_desc, data_ptr))
+		{
+			const FixedString64 instance_struct_name = make_instance_struct_type_name(type_desc, data_ptr);
+			FixedString256 type_name;
+			type_name = instance_struct_name.c_str();
 			return type_name;
 		}
 
@@ -3813,11 +3917,20 @@ namespace robotick
 
 	static size_t get_process_memory_used();
 
-	template <typename Writer> static void write_json_struct_ref(Writer& writer, const char* type_name, const size_t offset_within_container)
+	template <typename Writer>
+	static void write_json_struct_ref(Writer& writer, const TypeDescriptor* type_desc, void* data_ptr, const size_t offset_within_container)
 	{
 		writer.start_object();
 		writer.key("type");
-		writer.string(type_name ? type_name : "null");
+		if (type_desc)
+		{
+			const FixedString256 type_name = get_type_name(*type_desc, data_ptr);
+			writer.string(type_name.c_str());
+		}
+		else
+		{
+			writer.string("null");
+		}
 		writer.key("offset_within_container");
 		writer.int32(static_cast<int>(offset_within_container));
 		writer.end_object();
@@ -3980,17 +4093,17 @@ namespace robotick
 			if (desc->config_desc && workload_ptr)
 			{
 				writer.key("config");
-				write_json_struct_ref(writer, desc->config_desc->name.c_str(), desc->config_offset);
+				write_json_struct_ref(writer, desc->config_desc, (uint8_t*)workload_ptr + desc->config_offset, desc->config_offset);
 			}
 			if (desc->inputs_desc && workload_ptr)
 			{
 				writer.key("inputs");
-				write_json_struct_ref(writer, desc->inputs_desc->name.c_str(), desc->inputs_offset);
+				write_json_struct_ref(writer, desc->inputs_desc, (uint8_t*)workload_ptr + desc->inputs_offset, desc->inputs_offset);
 			}
 			if (desc->outputs_desc && workload_ptr)
 			{
 				writer.key("outputs");
-				write_json_struct_ref(writer, desc->outputs_desc->name.c_str(), desc->outputs_offset);
+				write_json_struct_ref(writer, desc->outputs_desc, (uint8_t*)workload_ptr + desc->outputs_offset, desc->outputs_offset);
 			}
 
 			writer.key("stats_offset_within_container");

--- a/cpp/src/robotick/framework/data/TelemetryServer.cpp
+++ b/cpp/src/robotick/framework/data/TelemetryServer.cpp
@@ -1602,6 +1602,7 @@ namespace robotick
 		static constexpr uint32_t ws_broadcast_tick_ms = 10;
 
 		void rebuild_writable_input_registry();
+		void refresh_writable_input_connection_handles();
 		int find_writable_input_index_by_handle(uint16_t handle) const;
 		int find_writable_input_index_by_path(const char* path) const;
 		int find_telemetry_peer_index_by_model_id(const char* model_id) const;
@@ -3141,7 +3142,11 @@ namespace robotick
 						{
 							continue;
 						}
-						DataConnectionInputHandle* input_handle = engine->find_data_connection_input_handle_by_overlap(field_ptr, field_type->size);
+						DataConnectionInputHandle* input_handle = engine->find_data_connection_input_handle_by_path(field_path.c_str());
+						if (!input_handle)
+						{
+							input_handle = engine->find_data_connection_input_handle_by_overlap(field_ptr, field_type->size);
+						}
 
 						on_leaf_ref(field_path, field_type, field_ptr, input_handle);
 					}
@@ -3191,6 +3196,30 @@ namespace robotick
 				pending_input_writes[write_index] = PendingInputWrite{};
 				++write_index;
 			});
+	}
+
+	void TelemetryServer::Impl::refresh_writable_input_connection_handles()
+	{
+		if (!engine)
+		{
+			return;
+		}
+
+		for (size_t i = 0; i < writable_input_fields.size(); ++i)
+		{
+			WritableInputField& writable = writable_input_fields[i];
+			if (writable.incoming_connection_handle)
+			{
+				continue;
+			}
+
+			DataConnectionInputHandle* input_handle = engine->find_data_connection_input_handle_by_path(writable.path.c_str());
+			if (!input_handle && writable.target_ptr && writable.value_size > 0)
+			{
+				input_handle = engine->find_data_connection_input_handle_by_overlap(writable.target_ptr, writable.value_size);
+			}
+			writable.incoming_connection_handle = input_handle;
+		}
 	}
 
 	void TelemetryServer::Impl::build_write_response_json(
@@ -3457,6 +3486,8 @@ namespace robotick
 			write_error(WebResponseCode::ServiceUnavailable, "engine_not_available");
 			return;
 		}
+
+		refresh_writable_input_connection_handles();
 
 		TelemetryConnectionStateRequestPayload payload;
 		JsonCursor cursor(request_body, request_size);
@@ -4011,6 +4042,7 @@ namespace robotick
 		}
 		res.set_body(cached_layout_body, cached_layout_body_size);
 #else
+		refresh_writable_input_connection_handles();
 		json::StringSink sink;
 		json::Writer<json::StringSink> writer(sink);
 		write_layout_json_stream(writer, *engine, session_id.c_str(), writable_input_fields);

--- a/cpp/src/robotick/framework/data/TelemetryServer.cpp
+++ b/cpp/src/robotick/framework/data/TelemetryServer.cpp
@@ -28,8 +28,8 @@
 #include <unistd.h>
 
 #if defined(ROBOTICK_PLATFORM_LINUX) || defined(ROBOTICK_PLATFORM_DESKTOP)
-#include <curl/curl.h>
 #include <arpa/inet.h>
+#include <curl/curl.h>
 #include <errno.h>
 #include <netdb.h>
 #include <netinet/in.h>
@@ -126,34 +126,6 @@ namespace robotick
 			return nullptr;
 		}
 
-		static bool has_incoming_connection_overlap(
-			const HeapVector<DataConnectionInfo>& connections, const void* target_ptr, const size_t target_size)
-		{
-			if (!target_ptr || target_size == 0)
-			{
-				return false;
-			}
-
-			const uintptr_t target_begin = reinterpret_cast<uintptr_t>(target_ptr);
-			const uintptr_t target_end = target_begin + target_size;
-
-			for (const DataConnectionInfo& connection : connections)
-			{
-				if (!connection.dest_ptr || connection.size == 0)
-				{
-					continue;
-				}
-
-				const uintptr_t connection_begin = reinterpret_cast<uintptr_t>(connection.dest_ptr);
-				const uintptr_t connection_end = connection_begin + connection.size;
-				if (target_begin < connection_end && connection_begin < target_end)
-				{
-					return true;
-				}
-			}
-			return false;
-		}
-
 		static bool uri_equals(const char* lhs, const char* rhs)
 		{
 			return lhs && rhs && StringView(lhs).equals(rhs);
@@ -202,6 +174,28 @@ namespace robotick
 			static constexpr size_t max_writes = 32;
 			HeapVector<TelemetryWriteRequestEntry> writes;
 			size_t write_count = 0;
+		};
+
+		struct TelemetryConnectionStateRequestEntry
+		{
+			bool has_field_handle = false;
+			uint16_t field_handle = 0;
+			bool has_field_path = false;
+			FixedString512 field_path;
+			bool has_enabled = false;
+			bool enabled = true;
+		};
+
+		struct TelemetryConnectionStateRequestPayload
+		{
+			TelemetryConnectionStateRequestPayload() { updates.initialize(max_updates); }
+
+			bool has_engine_session_id = false;
+			FixedString64 engine_session_id;
+			bool has_updates = false;
+			static constexpr size_t max_updates = 32;
+			HeapVector<TelemetryConnectionStateRequestEntry> updates;
+			size_t update_count = 0;
 		};
 
 		class JsonCursor
@@ -253,6 +247,70 @@ namespace robotick
 					{
 						out_payload.has_writes = true;
 						if (!parse_writes_array(out_payload.writes, out_payload.write_count))
+						{
+							return false;
+						}
+					}
+					else if (!skip_value())
+					{
+						return false;
+					}
+
+					skip_ws();
+					if (consume('}'))
+					{
+						return true;
+					}
+					if (!consume(','))
+					{
+						return false;
+					}
+					skip_ws();
+				}
+
+				return false;
+			}
+
+			bool parse_connection_state_request(TelemetryConnectionStateRequestPayload& out_payload)
+			{
+				skip_ws();
+				if (!consume('{'))
+				{
+					return false;
+				}
+
+				skip_ws();
+				if (consume('}'))
+				{
+					return true;
+				}
+
+				while (!is_at_end())
+				{
+					FixedString64 key;
+					if (!parse_string(key))
+					{
+						return false;
+					}
+					skip_ws();
+					if (!consume(':'))
+					{
+						return false;
+					}
+					skip_ws();
+
+					if (key == "engine_session_id")
+					{
+						out_payload.has_engine_session_id = parse_string(out_payload.engine_session_id);
+						if (!out_payload.has_engine_session_id)
+						{
+							return false;
+						}
+					}
+					else if (key == "updates")
+					{
+						out_payload.has_updates = true;
+						if (!parse_connection_updates_array(out_payload.updates, out_payload.update_count))
 						{
 							return false;
 						}
@@ -478,6 +536,23 @@ namespace robotick
 
 				out.assign(start, static_cast<size_t>(cur - start));
 				return true;
+			}
+
+			bool parse_bool(bool& out)
+			{
+				if (matches_literal("true"))
+				{
+					out = true;
+					cur += 4;
+					return true;
+				}
+				if (matches_literal("false"))
+				{
+					out = false;
+					cur += 5;
+					return true;
+				}
+				return false;
 			}
 
 			bool skip_string()
@@ -739,6 +814,121 @@ namespace robotick
 						return false;
 					}
 					out_writes[out_count] = entry;
+					out_count += 1;
+
+					skip_ws();
+					if (consume(']'))
+					{
+						return true;
+					}
+					if (!consume(','))
+					{
+						return false;
+					}
+					skip_ws();
+				}
+
+				return false;
+			}
+
+			bool parse_single_connection_update(TelemetryConnectionStateRequestEntry& out_entry)
+			{
+				if (!consume('{'))
+				{
+					return false;
+				}
+				skip_ws();
+				if (consume('}'))
+				{
+					return true;
+				}
+
+				while (!is_at_end())
+				{
+					FixedString64 key;
+					if (!parse_string(key))
+					{
+						return false;
+					}
+					skip_ws();
+					if (!consume(':'))
+					{
+						return false;
+					}
+					skip_ws();
+
+					if (key == "field_handle")
+					{
+						int64_t parsed_handle = 0;
+						if (!parse_integer(parsed_handle) || parsed_handle <= 0 || parsed_handle > 0xFFFF)
+						{
+							return false;
+						}
+						out_entry.has_field_handle = true;
+						out_entry.field_handle = static_cast<uint16_t>(parsed_handle);
+					}
+					else if (key == "field_path")
+					{
+						out_entry.has_field_path = parse_string(out_entry.field_path);
+						if (!out_entry.has_field_path)
+						{
+							return false;
+						}
+					}
+					else if (key == "enabled")
+					{
+						out_entry.has_enabled = parse_bool(out_entry.enabled);
+						if (!out_entry.has_enabled)
+						{
+							return false;
+						}
+					}
+					else if (!skip_value())
+					{
+						return false;
+					}
+
+					skip_ws();
+					if (consume('}'))
+					{
+						return true;
+					}
+					if (!consume(','))
+					{
+						return false;
+					}
+					skip_ws();
+				}
+
+				return false;
+			}
+
+			bool parse_connection_updates_array(HeapVector<TelemetryConnectionStateRequestEntry>& out_updates, size_t& out_count)
+			{
+				if (!consume('['))
+				{
+					return false;
+				}
+
+				skip_ws();
+				if (consume(']'))
+				{
+					return true;
+				}
+
+				while (!is_at_end())
+				{
+					if (out_count >= out_updates.size())
+					{
+						return false;
+					}
+
+					TelemetryConnectionStateRequestEntry entry;
+					if (!parse_single_connection_update(entry))
+					{
+						return false;
+					}
+					out_updates[out_count] = entry;
 					out_count += 1;
 
 					skip_ws();
@@ -1202,14 +1392,13 @@ namespace robotick
 				return false;
 			}
 
-			const char* handshake =
-				"GET %s HTTP/1.1\r\n"
-				"Host: %s:%u\r\n"
-				"Upgrade: websocket\r\n"
-				"Connection: Upgrade\r\n"
-				"Sec-WebSocket-Version: 13\r\n"
-				"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
-				"\r\n";
+			const char* handshake = "GET %s HTTP/1.1\r\n"
+									"Host: %s:%u\r\n"
+									"Upgrade: websocket\r\n"
+									"Connection: Upgrade\r\n"
+									"Sec-WebSocket-Version: 13\r\n"
+									"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+									"\r\n";
 
 			char request[1024];
 			::snprintf(request, sizeof(request), handshake, path, host, static_cast<unsigned>(port));
@@ -1314,6 +1503,7 @@ namespace robotick
 			const TypeDescriptor* type_desc = nullptr;
 			void* target_ptr = nullptr;
 			uint16_t value_size = 0;
+			DataConnectionInputHandle* incoming_connection_handle = nullptr;
 		};
 
 		struct PendingInputWrite
@@ -1429,6 +1619,7 @@ namespace robotick
 		void send_ws_error(const WebSocketConnection& connection, const char* error_text);
 		bool handle_ws_message(const WsRoute& route, const WebSocketConnection& connection, const WebSocketMessage& message);
 		void build_write_response_json(const char* request_body, size_t request_size, int& out_status_code, json::StringSink& out_json);
+		void build_connection_state_response_json(const char* request_body, size_t request_size, int& out_status_code, json::StringSink& out_json);
 		void maybe_broadcast_local_frame(const Clock::time_point now);
 		void maybe_broadcast_peer_frames(const Clock::time_point now);
 		void maybe_send_heartbeats(const Clock::time_point now);
@@ -1453,6 +1644,7 @@ namespace robotick
 		void handle_get_workloads_buffer_layout(const WebRequest& req, WebResponse& res);
 		void handle_get_workloads_buffer_raw(const WebRequest& req, WebResponse& res);
 		void handle_set_workload_input_fields_data(const WebRequest& req, WebResponse& res);
+		void handle_set_workload_input_connection_state(const WebRequest& req, WebResponse& res);
 	};
 
 	TelemetryServer::TelemetryServer()
@@ -1541,19 +1733,25 @@ namespace robotick
 					FixedString128 routed_suffix_uri;
 					if (try_parse_model_routed_uri(req.uri.c_str(), routed_model_id, routed_suffix_uri))
 					{
-						set_json_response(res,
-							WebResponseCode::NotFound,
-							[&](auto& writer)
-							{
-								writer.start_object();
-								writer.key("error");
-								writer.string("telemetry_rest_data_plane_removed");
-								writer.key("model_id");
-								writer.string(routed_model_id.c_str());
-								writer.key("path");
-								writer.string(routed_suffix_uri.c_str());
-								writer.end_object();
-							});
+						const int peer_index = impl->find_telemetry_peer_index_by_model_id(routed_model_id.c_str());
+						if (peer_index < 0)
+						{
+							set_json_response(res,
+								WebResponseCode::NotFound,
+								[&](auto& writer)
+								{
+									writer.start_object();
+									writer.key("error");
+									writer.string("telemetry_peer_not_found");
+									writer.key("model_id");
+									writer.string(routed_model_id.c_str());
+									writer.end_object();
+								});
+							return true;
+						}
+
+						impl->handle_forwarded_telemetry_request(
+							req, res, impl->telemetry_peers[static_cast<size_t>(peer_index)], routed_suffix_uri.c_str());
 						return true;
 					}
 				}
@@ -2196,8 +2394,7 @@ namespace robotick
 			send_ws_error(client.connection, "telemetry_forward_failed");
 			return;
 		}
-		if (!client.connection.send_frame(
-				0x1,
+		if (!client.connection.send_frame(0x1,
 				peer.peer_ws_latest_layout_size > 0 ? reinterpret_cast<const void*>(peer.peer_ws_latest_layout.data()) : "{}",
 				peer.peer_ws_latest_layout_size))
 		{
@@ -2461,10 +2658,10 @@ namespace robotick
 			{
 				const WsClient& client = clients[i];
 				const bool metadata_ok = client.connection.send_text(metadata.c_str());
-				const bool frame_ok = metadata_ok &&
-					client.connection.send_binary(
-						peer.peer_ws_latest_raw.size() > 0 ? reinterpret_cast<const void*>(peer.peer_ws_latest_raw.data()) : nullptr,
-						peer.peer_ws_latest_raw.size());
+				const bool frame_ok =
+					metadata_ok && client.connection.send_binary(
+									   peer.peer_ws_latest_raw.size() > 0 ? reinterpret_cast<const void*>(peer.peer_ws_latest_raw.data()) : nullptr,
+									   peer.peer_ws_latest_raw.size());
 				if (!frame_ok)
 				{
 					unregister_ws_client(client.connection);
@@ -2579,8 +2776,7 @@ namespace robotick
 			return true;
 		}
 
-		const bool sent = connection.send_frame(
-			0x1,
+		const bool sent = connection.send_frame(0x1,
 			peer.peer_ws_write_response_size > 0 ? reinterpret_cast<const void*>(peer.peer_ws_write_response.data()) : "",
 			peer.peer_ws_write_response_size);
 		if (!sent)
@@ -2603,6 +2799,29 @@ namespace robotick
 			{
 				res.set_status_code(WebResponseCode::OK);
 				res.set_body(nullptr, 0);
+				return true;
+			}
+			if (uri_equals(effective_uri, "/api/telemetry/workloads_buffer/layout"))
+			{
+				handle_get_workloads_buffer_layout(req, res);
+				return true;
+			}
+			if (uri_equals(effective_uri, "/api/telemetry/workloads_buffer/raw"))
+			{
+				handle_get_workloads_buffer_raw(req, res);
+				return true;
+			}
+		}
+		else if (req.method.equals("POST"))
+		{
+			if (uri_equals(effective_uri, "/api/telemetry/set_workload_input_fields_data"))
+			{
+				handle_set_workload_input_fields_data(req, res);
+				return true;
+			}
+			if (uri_equals(effective_uri, "/api/telemetry/set_workload_input_connection_state"))
+			{
+				handle_set_workload_input_connection_state(req, res);
 				return true;
 			}
 		}
@@ -2672,6 +2891,7 @@ namespace robotick
 		const bool is_layout_request = is_get && StringView(suffix_uri).equals("/workloads_buffer/layout");
 		const bool is_raw_request = is_get && StringView(suffix_uri).equals("/workloads_buffer/raw");
 		const bool is_write_request = is_post && StringView(suffix_uri).equals("/set_workload_input_fields_data");
+		const bool is_connection_state_request = is_post && StringView(suffix_uri).equals("/set_workload_input_connection_state");
 
 		auto forward_or_error = [&](ForwardHttpResult& out_result) -> bool
 		{
@@ -2781,7 +3001,7 @@ namespace robotick
 			return;
 		}
 
-		if (is_write_request)
+		if (is_write_request || is_connection_state_request)
 		{
 			LockGuard lock(const_cast<Mutex&>(peer.forwarded_write_mutex));
 			if (!forward_or_error(forwarded))
@@ -2842,8 +3062,6 @@ namespace robotick
 
 		WorkloadsBuffer& workloads_buffer = engine->get_workloads_buffer();
 		const auto& instances = engine->get_all_instance_info();
-		const auto& incoming_connections = engine->get_all_data_connections();
-
 		const auto for_each_writable_input_leaf = [&](auto&& on_leaf)
 		{
 			for (const WorkloadInstanceInfo& workload_instance_info : instances)
@@ -2923,12 +3141,9 @@ namespace robotick
 						{
 							continue;
 						}
-						if (has_incoming_connection_overlap(incoming_connections, field_ptr, field_type->size))
-						{
-							continue;
-						}
+						DataConnectionInputHandle* input_handle = engine->find_data_connection_input_handle_by_overlap(field_ptr, field_type->size);
 
-						on_leaf_ref(field_path, field_type, field_ptr);
+						on_leaf_ref(field_path, field_type, field_ptr, input_handle);
 					}
 				};
 
@@ -2938,7 +3153,7 @@ namespace robotick
 
 		size_t writable_count = 0;
 		for_each_writable_input_leaf(
-			[&](const FixedString512&, const TypeDescriptor*, void*)
+			[&](const FixedString512&, const TypeDescriptor*, void*, DataConnectionInputHandle*)
 			{
 				++writable_count;
 			});
@@ -2959,7 +3174,7 @@ namespace robotick
 
 		size_t write_index = 0;
 		for_each_writable_input_leaf(
-			[&](const FixedString512& field_path, const TypeDescriptor* field_type, void* field_ptr)
+			[&](const FixedString512& field_path, const TypeDescriptor* field_type, void* field_ptr, DataConnectionInputHandle* input_handle)
 			{
 				if (write_index >= writable_count)
 				{
@@ -2972,6 +3187,7 @@ namespace robotick
 				writable.type_desc = field_type;
 				writable.target_ptr = field_ptr;
 				writable.value_size = static_cast<uint16_t>(field_type ? field_type->size : 0);
+				writable.incoming_connection_handle = input_handle;
 				pending_input_writes[write_index] = PendingInputWrite{};
 				++write_index;
 			});
@@ -3213,11 +3429,167 @@ namespace robotick
 		writer.flush();
 	}
 
+	void TelemetryServer::Impl::build_connection_state_response_json(
+		const char* request_body, const size_t request_size, int& out_status_code, json::StringSink& out_json)
+	{
+		struct UpdateResult
+		{
+			uint16_t field_handle = 0;
+			FixedString512 field_path;
+			uint16_t connection_handle = 0;
+			bool enabled = true;
+			const char* status = "";
+		};
+
+		auto write_error = [&](const int status, const char* error_text)
+		{
+			out_status_code = status;
+			json::Writer<json::StringSink> writer(out_json);
+			writer.start_object();
+			writer.key("error");
+			writer.string(error_text ? error_text : "unknown_error");
+			writer.end_object();
+			writer.flush();
+		};
+
+		if (!engine)
+		{
+			write_error(WebResponseCode::ServiceUnavailable, "engine_not_available");
+			return;
+		}
+
+		TelemetryConnectionStateRequestPayload payload;
+		JsonCursor cursor(request_body, request_size);
+		if (!cursor.parse_connection_state_request(payload))
+		{
+			write_error(WebResponseCode::BadRequest, "invalid_json");
+			return;
+		}
+
+		const bool session_matches = !payload.has_engine_session_id || StringView(session_id.c_str()).equals(payload.engine_session_id.c_str());
+		if (!payload.has_updates || payload.update_count == 0)
+		{
+			write_error(WebResponseCode::BadRequest, "missing_updates");
+			return;
+		}
+
+		HeapVector<UpdateResult> results;
+		results.initialize(payload.update_count);
+
+		for (size_t update_payload_index = 0; update_payload_index < payload.update_count; ++update_payload_index)
+		{
+			const TelemetryConnectionStateRequestEntry& update_payload = payload.updates[update_payload_index];
+			if (!session_matches && !update_payload.has_field_path)
+			{
+				write_error(WebResponseCode::PreconditionFailed, "field_path_required_for_stale_session_write");
+				return;
+			}
+
+			int writable_index = -1;
+			uint16_t writable_handle = 0;
+			FixedString512 requested_path;
+
+			if (update_payload.has_field_handle)
+			{
+				writable_handle = update_payload.field_handle;
+				writable_index = find_writable_input_index_by_handle(writable_handle);
+			}
+
+			if (update_payload.has_field_path)
+			{
+				requested_path = update_payload.field_path.c_str();
+				const int path_index = find_writable_input_index_by_path(requested_path.c_str());
+				if (path_index >= 0)
+				{
+					if (writable_index >= 0 && static_cast<size_t>(writable_index) != static_cast<size_t>(path_index))
+					{
+						write_error(WebResponseCode::BadRequest, "field_handle_path_mismatch");
+						return;
+					}
+					writable_index = path_index;
+					writable_handle = writable_input_fields[static_cast<size_t>(writable_index)].handle;
+				}
+			}
+
+			if (writable_index < 0)
+			{
+				write_error(WebResponseCode::NotFound, "writable_input_not_found");
+				return;
+			}
+
+			if (!update_payload.has_enabled)
+			{
+				write_error(WebResponseCode::BadRequest, "missing_enabled");
+				return;
+			}
+
+			WritableInputField& writable = writable_input_fields[static_cast<size_t>(writable_index)];
+			if (!writable.incoming_connection_handle)
+			{
+				write_error(WebResponseCode::Conflict, "writable_input_has_no_incoming_connection");
+				return;
+			}
+
+			writable.incoming_connection_handle->set_enabled(update_payload.enabled);
+
+			UpdateResult& result = results[update_payload_index];
+			result.field_handle = writable_handle;
+			result.field_path = writable.path.c_str();
+			result.connection_handle = writable.incoming_connection_handle->handle_id;
+			result.enabled = writable.incoming_connection_handle->is_enabled();
+			result.status = "accepted";
+		}
+
+#if defined(ROBOTICK_PLATFORM_ESP32S3)
+		rebuild_layout_cache();
+#endif
+
+		out_status_code = WebResponseCode::OK;
+		json::Writer<json::StringSink> writer(out_json);
+		writer.start_object();
+		writer.key("status");
+		writer.string("processed");
+		writer.key("engine_session_id");
+		writer.string(session_id.c_str());
+		writer.key("updates");
+		writer.start_array();
+		for (size_t i = 0; i < payload.update_count; ++i)
+		{
+			const UpdateResult& result = results[i];
+			writer.start_object();
+			writer.key("field_handle");
+			writer.uint64(result.field_handle);
+			writer.key("field_path");
+			writer.string(result.field_path);
+			writer.key("incoming_connection_handle");
+			writer.uint64(result.connection_handle);
+			writer.key("incoming_connection_enabled");
+			writer.boolean(result.enabled);
+			writer.key("status");
+			writer.string(result.status);
+			writer.end_object();
+		}
+		writer.end_array();
+		writer.end_object();
+		writer.flush();
+	}
+
 	void TelemetryServer::Impl::handle_set_workload_input_fields_data(const WebRequest& req, WebResponse& res)
 	{
 		json::StringSink response_body;
 		int status_code = WebResponseCode::InternalServerError;
 		build_write_response_json(reinterpret_cast<const char*>(req.body.data()), req.body.size(), status_code, response_body);
+
+		res.set_status_code(status_code);
+		res.set_content_type("application/json");
+		res.set_body(response_body.c_str(), response_body.size());
+	}
+
+	void TelemetryServer::Impl::handle_set_workload_input_connection_state(const WebRequest& req, WebResponse& res)
+	{
+		json::StringSink response_body;
+		int status_code = WebResponseCode::InternalServerError;
+		build_connection_state_response_json(reinterpret_cast<const char*>(req.body.data()), req.body.size(), status_code, response_body);
 
 		res.set_status_code(status_code);
 		res.set_content_type("application/json");
@@ -3538,6 +3910,15 @@ namespace robotick
 			writer.string(writable.type_desc ? writable.type_desc->name.c_str() : "unknown");
 			writer.key("size");
 			writer.uint64(static_cast<uint64_t>(writable.value_size));
+			if (writable.incoming_connection_handle)
+			{
+				writer.key("incoming_connection_handle");
+				writer.uint64(static_cast<uint64_t>(writable.incoming_connection_handle->handle_id));
+				writer.key("incoming_connection_path");
+				writer.string(writable.incoming_connection_handle->path.c_str());
+				writer.key("incoming_connection_enabled");
+				writer.boolean(writable.incoming_connection_handle->is_enabled());
+			}
 			writer.end_object();
 		}
 		writer.end_array();

--- a/cpp/src/robotick/framework/data/TelemetryServer.cpp
+++ b/cpp/src/robotick/framework/data/TelemetryServer.cpp
@@ -1545,6 +1545,7 @@ namespace robotick
 			HeapVector<char> peer_ws_latest_layout;
 			size_t peer_ws_latest_layout_size = 0;
 			bool peer_ws_has_latest_layout = false;
+			uint32_t peer_ws_latest_layout_seq = 0;
 			HeapVector<char> peer_ws_write_response;
 			size_t peer_ws_write_response_size = 0;
 			bool peer_ws_has_write_response = false;
@@ -1598,7 +1599,9 @@ namespace robotick
 		Thread ws_broadcast_thread;
 		uint32_t ws_last_local_frame_seq = 0;
 		HeapVector<uint32_t> ws_last_peer_frame_seq;
+		HeapVector<uint32_t> ws_last_peer_layout_seq;
 		size_t last_known_writable_connection_handle_count = 0;
+		AtomicFlag ws_layout_dirty{false};
 		static constexpr uint32_t ws_heartbeat_interval_ms = 1000;
 		static constexpr uint32_t ws_broadcast_tick_ms = 10;
 
@@ -1932,12 +1935,21 @@ namespace robotick
 		{
 			ws_last_peer_frame_seq.initialize(telemetry_peers.size());
 		}
+		if (!telemetry_peers.empty() && ws_last_peer_layout_seq.empty())
+		{
+			ws_last_peer_layout_seq.initialize(telemetry_peers.size());
+		}
 		for (size_t i = 0; i < ws_last_peer_frame_seq.size(); ++i)
 		{
 			ws_last_peer_frame_seq[i] = 0;
 		}
+		for (size_t i = 0; i < ws_last_peer_layout_seq.size(); ++i)
+		{
+			ws_last_peer_layout_seq[i] = 0;
+		}
 
 		ws_last_local_frame_seq = 0;
+		ws_layout_dirty.clear();
 		ws_broadcast_stop.clear();
 	}
 
@@ -1964,6 +1976,7 @@ namespace robotick
 		peer.peer_ws_latest_layout.reset();
 		peer.peer_ws_latest_layout_size = 0;
 		peer.peer_ws_has_latest_layout = false;
+		peer.peer_ws_latest_layout_seq = 0;
 		peer.peer_ws_write_response.reset();
 		peer.peer_ws_write_response_size = 0;
 		peer.peer_ws_has_write_response = false;
@@ -2091,6 +2104,7 @@ namespace robotick
 					peer.peer_ws_latest_layout[payload_size] = '\0';
 					peer.peer_ws_latest_layout_size = payload_size;
 					peer.peer_ws_has_latest_layout = true;
+					++peer.peer_ws_latest_layout_seq;
 					continue;
 				}
 				if (::strstr(body, "\"accepted_count\"") || ::strstr(body, "\"ignored_stale_count\"") || ::strstr(body, "\"error\""))
@@ -2552,12 +2566,17 @@ namespace robotick
 
 		const bool refreshed = refresh_writable_input_connection_handles();
 		const size_t current_count = count_writable_input_connection_handles();
-		if (!refreshed && current_count == last_known_writable_connection_handle_count)
+		const bool layout_dirty = ws_layout_dirty.is_set();
+		if (!refreshed && current_count == last_known_writable_connection_handle_count && !layout_dirty)
 		{
 			return;
 		}
 
 		last_known_writable_connection_handle_count = current_count;
+		if (layout_dirty)
+		{
+			ws_layout_dirty.clear();
+		}
 
 #if defined(ROBOTICK_PLATFORM_ESP32S3)
 		rebuild_layout_cache();
@@ -2681,6 +2700,21 @@ namespace robotick
 				if (!pump_peer_ws_messages(peer, 8, 0))
 				{
 					continue;
+				}
+				if (peer.peer_ws_has_latest_layout && !ws_last_peer_layout_seq.empty() && peer_index < ws_last_peer_layout_seq.size() &&
+					ws_last_peer_layout_seq[peer_index] != peer.peer_ws_latest_layout_seq)
+				{
+					for (size_t i = 0; i < clients.size(); ++i)
+					{
+						const WsClient& client = clients[i];
+						if (!client.connection.send_frame(0x1,
+								peer.peer_ws_latest_layout_size > 0 ? reinterpret_cast<const void*>(peer.peer_ws_latest_layout.data()) : "{}",
+								peer.peer_ws_latest_layout_size))
+						{
+							unregister_ws_client(client.connection);
+						}
+					}
+					ws_last_peer_layout_seq[peer_index] = peer.peer_ws_latest_layout_seq;
 				}
 				if (!peer.peer_ws_has_latest_raw)
 				{
@@ -3634,7 +3668,12 @@ namespace robotick
 				return;
 			}
 
+			const bool was_enabled = writable.incoming_connection_handle->is_enabled();
 			writable.incoming_connection_handle->set_enabled(update_payload.enabled);
+			if (was_enabled != update_payload.enabled)
+			{
+				ws_layout_dirty.set();
+			}
 
 			UpdateResult& result = results[update_payload_index];
 			result.field_handle = writable_handle;

--- a/cpp/src/robotick/framework/data/TelemetryServer.cpp
+++ b/cpp/src/robotick/framework/data/TelemetryServer.cpp
@@ -1523,15 +1523,11 @@ namespace robotick
 #if defined(ROBOTICK_PLATFORM_LINUX) || defined(ROBOTICK_PLATFORM_DESKTOP)
 			Mutex forwarded_request_mutex;
 			Mutex forwarded_raw_mutex;
-			Mutex forwarded_layout_mutex;
 			Mutex forwarded_write_mutex;
 			ForwardHttpResult cached_raw;
-			ForwardHttpResult cached_layout;
 			Clock::time_point cached_raw_at{};
 			bool has_cached_raw = false;
-			bool has_cached_layout = false;
 			FixedString64 last_seen_session_id;
-			FixedString64 cached_layout_session_id;
 			int peer_ws_fd = -1;
 			Clock::time_point peer_ws_last_connect_attempt{};
 			bool peer_ws_has_pending_frame_meta = false;
@@ -2993,12 +2989,6 @@ namespace robotick
 
 		if (is_layout_request)
 		{
-			LockGuard lock(const_cast<Mutex&>(peer.forwarded_layout_mutex));
-			if (peer.has_cached_layout)
-			{
-				apply_forward_http_result_to_response(peer.cached_layout, res);
-				return;
-			}
 			if (!forward_or_error(forwarded))
 			{
 				set_json_response(res,
@@ -3017,9 +3007,6 @@ namespace robotick
 				return;
 			}
 
-			copy_forward_http_result(forwarded, const_cast<ForwardHttpResult&>(peer.cached_layout));
-			const_cast<TelemetryPeerRoute&>(peer).has_cached_layout = true;
-			const_cast<TelemetryPeerRoute&>(peer).cached_layout_session_id = peer.last_seen_session_id;
 			apply_forward_http_result_to_response(forwarded, res);
 			return;
 		}
@@ -3071,24 +3058,11 @@ namespace robotick
 			TelemetryPeerRoute& mutable_peer = const_cast<TelemetryPeerRoute&>(peer);
 			if (!forwarded.session_header.empty())
 			{
-				if (!mutable_peer.last_seen_session_id.empty() && mutable_peer.last_seen_session_id != forwarded.session_header)
-				{
-					reset_forward_http_result(mutable_peer.cached_layout);
-					mutable_peer.has_cached_layout = false;
-					mutable_peer.cached_layout_session_id.clear();
-				}
 				mutable_peer.last_seen_session_id = forwarded.session_header;
 			}
 			copy_forward_http_result(forwarded, mutable_peer.cached_raw);
 			mutable_peer.cached_raw_at = now;
 			mutable_peer.has_cached_raw = true;
-			if (!mutable_peer.cached_layout_session_id.empty() && !mutable_peer.last_seen_session_id.empty() &&
-				mutable_peer.cached_layout_session_id != mutable_peer.last_seen_session_id)
-			{
-				reset_forward_http_result(mutable_peer.cached_layout);
-				mutable_peer.has_cached_layout = false;
-				mutable_peer.cached_layout_session_id.clear();
-			}
 			apply_forward_http_result_to_response(forwarded, res);
 			return;
 		}
@@ -3112,14 +3086,6 @@ namespace robotick
 						writer.end_object();
 					});
 				return;
-			}
-			if (is_connection_state_request && forwarded.status_code == WebResponseCode::OK)
-			{
-				TelemetryPeerRoute& mutable_peer = const_cast<TelemetryPeerRoute&>(peer);
-				LockGuard layout_lock(mutable_peer.forwarded_layout_mutex);
-				reset_forward_http_result(mutable_peer.cached_layout);
-				mutable_peer.has_cached_layout = false;
-				mutable_peer.cached_layout_session_id.clear();
 			}
 			apply_forward_http_result_to_response(forwarded, res);
 			return;

--- a/cpp/src/robotick/framework/data/TelemetryServer.cpp
+++ b/cpp/src/robotick/framework/data/TelemetryServer.cpp
@@ -1574,6 +1574,7 @@ namespace robotick
 		FixedString64 session_id;
 		HeapVector<WritableInputField> writable_input_fields;
 		HeapVector<PendingInputWrite> pending_input_writes;
+		Mutex writable_input_fields_mutex;
 #if defined(ROBOTICK_PLATFORM_ESP32S3)
 		Mutex layout_cache_mutex;
 		static constexpr size_t layout_cache_capacity = 16384;
@@ -1608,6 +1609,7 @@ namespace robotick
 		void rebuild_writable_input_registry();
 		bool refresh_writable_input_connection_handles();
 		size_t count_writable_input_connection_handles() const;
+		size_t count_writable_input_connection_handles_unlocked() const;
 		int find_writable_input_index_by_handle(uint16_t handle) const;
 		int find_writable_input_index_by_path(const char* path) const;
 		int find_telemetry_peer_index_by_model_id(const char* model_id) const;
@@ -1794,7 +1796,8 @@ namespace robotick
 			return;
 		}
 
-		LockGuard lock(impl->pending_input_writes_mutex);
+		LockGuard writable_lock(impl->writable_input_fields_mutex);
+		LockGuard pending_lock(impl->pending_input_writes_mutex);
 		const size_t writable_count = impl->writable_input_fields.size();
 		const size_t pending_count = impl->pending_input_writes.size();
 		const size_t count = min(writable_count, pending_count);
@@ -2396,8 +2399,11 @@ namespace robotick
 			(void)refreshed;
 			json::StringSink layout_sink;
 			json::Writer<json::StringSink> writer(layout_sink);
-			write_layout_json_stream(writer, *engine, session_id.c_str(), writable_input_fields);
-			writer.flush();
+			{
+				LockGuard writable_lock(writable_input_fields_mutex);
+				write_layout_json_stream(writer, *engine, session_id.c_str(), writable_input_fields);
+				writer.flush();
+			}
 			if (!client.connection.send_frame(0x1, layout_sink.c_str(), layout_sink.size()))
 			{
 				unregister_ws_client(client.connection);
@@ -3107,6 +3113,14 @@ namespace robotick
 					});
 				return;
 			}
+			if (is_connection_state_request && forwarded.status_code == WebResponseCode::OK)
+			{
+				TelemetryPeerRoute& mutable_peer = const_cast<TelemetryPeerRoute&>(peer);
+				LockGuard layout_lock(mutable_peer.forwarded_layout_mutex);
+				reset_forward_http_result(mutable_peer.cached_layout);
+				mutable_peer.has_cached_layout = false;
+				mutable_peer.cached_layout_session_id.clear();
+			}
 			apply_forward_http_result_to_response(forwarded, res);
 			return;
 		}
@@ -3139,6 +3153,9 @@ namespace robotick
 
 	void TelemetryServer::Impl::rebuild_writable_input_registry()
 	{
+		LockGuard writable_lock(writable_input_fields_mutex);
+		LockGuard pending_lock(pending_input_writes_mutex);
+
 		write_seq_counter = 0;
 
 		if (!engine)
@@ -3282,10 +3299,10 @@ namespace robotick
 				++write_index;
 			});
 
-		last_known_writable_connection_handle_count = count_writable_input_connection_handles();
+		last_known_writable_connection_handle_count = count_writable_input_connection_handles_unlocked();
 	}
 
-	size_t TelemetryServer::Impl::count_writable_input_connection_handles() const
+	size_t TelemetryServer::Impl::count_writable_input_connection_handles_unlocked() const
 	{
 		size_t count = 0;
 		for (size_t i = 0; i < writable_input_fields.size(); ++i)
@@ -3298,6 +3315,12 @@ namespace robotick
 		return count;
 	}
 
+	size_t TelemetryServer::Impl::count_writable_input_connection_handles() const
+	{
+		LockGuard lock(const_cast<Mutex&>(writable_input_fields_mutex));
+		return count_writable_input_connection_handles_unlocked();
+	}
+
 	bool TelemetryServer::Impl::refresh_writable_input_connection_handles()
 	{
 		if (!engine)
@@ -3305,6 +3328,7 @@ namespace robotick
 			return false;
 		}
 
+		LockGuard lock(writable_input_fields_mutex);
 		bool changed = false;
 		for (size_t i = 0; i < writable_input_fields.size(); ++i)
 		{
@@ -3370,6 +3394,8 @@ namespace robotick
 			write_error(WebResponseCode::BadRequest, "missing_writes");
 			return;
 		}
+
+		LockGuard writable_lock(writable_input_fields_mutex);
 
 		HeapVector<ParsedWrite> parsed_writes;
 		parsed_writes.initialize(payload.write_count);
@@ -3489,7 +3515,7 @@ namespace robotick
 		size_t ignored_stale_count = 0;
 
 		{
-			LockGuard lock(pending_input_writes_mutex);
+			LockGuard pending_lock(pending_input_writes_mutex);
 			for (size_t i = 0; i < parsed_count; ++i)
 			{
 				ParsedWrite& parsed = parsed_writes[i];
@@ -3614,77 +3640,87 @@ namespace robotick
 		HeapVector<UpdateResult> results;
 		results.initialize(payload.update_count);
 
-		for (size_t update_payload_index = 0; update_payload_index < payload.update_count; ++update_payload_index)
+		bool layout_cache_needs_rebuild = false;
 		{
-			const TelemetryConnectionStateRequestEntry& update_payload = payload.updates[update_payload_index];
-			if (!session_matches && !update_payload.has_field_path)
+			LockGuard writable_lock(writable_input_fields_mutex);
+			for (size_t update_payload_index = 0; update_payload_index < payload.update_count; ++update_payload_index)
 			{
-				write_error(WebResponseCode::PreconditionFailed, "field_path_required_for_stale_session_write");
-				return;
-			}
-
-			int writable_index = -1;
-			uint16_t writable_handle = 0;
-			FixedString512 requested_path;
-
-			if (update_payload.has_field_handle)
-			{
-				writable_handle = update_payload.field_handle;
-				writable_index = find_writable_input_index_by_handle(writable_handle);
-			}
-
-			if (update_payload.has_field_path)
-			{
-				requested_path = update_payload.field_path.c_str();
-				const int path_index = find_writable_input_index_by_path(requested_path.c_str());
-				if (path_index >= 0)
+				const TelemetryConnectionStateRequestEntry& update_payload = payload.updates[update_payload_index];
+				if (!session_matches && !update_payload.has_field_path)
 				{
-					if (writable_index >= 0 && static_cast<size_t>(writable_index) != static_cast<size_t>(path_index))
-					{
-						write_error(WebResponseCode::BadRequest, "field_handle_path_mismatch");
-						return;
-					}
-					writable_index = path_index;
-					writable_handle = writable_input_fields[static_cast<size_t>(writable_index)].handle;
+					write_error(WebResponseCode::PreconditionFailed, "field_path_required_for_stale_session_write");
+					return;
 				}
-			}
 
-			if (writable_index < 0)
-			{
-				write_error(WebResponseCode::NotFound, "writable_input_not_found");
-				return;
-			}
+				int writable_index = -1;
+				uint16_t writable_handle = 0;
+				FixedString512 requested_path;
 
-			if (!update_payload.has_enabled)
-			{
-				write_error(WebResponseCode::BadRequest, "missing_enabled");
-				return;
-			}
+				if (update_payload.has_field_handle)
+				{
+					writable_handle = update_payload.field_handle;
+					writable_index = find_writable_input_index_by_handle(writable_handle);
+				}
 
-			WritableInputField& writable = writable_input_fields[static_cast<size_t>(writable_index)];
-			if (!writable.incoming_connection_handle)
-			{
-				write_error(WebResponseCode::Conflict, "writable_input_has_no_incoming_connection");
-				return;
-			}
+				if (update_payload.has_field_path)
+				{
+					requested_path = update_payload.field_path.c_str();
+					const int path_index = find_writable_input_index_by_path(requested_path.c_str());
+					if (path_index >= 0)
+					{
+						if (writable_index >= 0 && static_cast<size_t>(writable_index) != static_cast<size_t>(path_index))
+						{
+							write_error(WebResponseCode::BadRequest, "field_handle_path_mismatch");
+							return;
+						}
+						writable_index = path_index;
+						writable_handle = writable_input_fields[static_cast<size_t>(writable_index)].handle;
+					}
+				}
 
-			const bool was_enabled = writable.incoming_connection_handle->is_enabled();
-			writable.incoming_connection_handle->set_enabled(update_payload.enabled);
-			if (was_enabled != update_payload.enabled)
-			{
-				ws_layout_dirty.set();
-			}
+				if (writable_index < 0)
+				{
+					write_error(WebResponseCode::NotFound, "writable_input_not_found");
+					return;
+				}
 
-			UpdateResult& result = results[update_payload_index];
-			result.field_handle = writable_handle;
-			result.field_path = writable.path.c_str();
-			result.connection_handle = writable.incoming_connection_handle->handle_id;
-			result.enabled = writable.incoming_connection_handle->is_enabled();
-			result.status = "accepted";
+				if (!update_payload.has_enabled)
+				{
+					write_error(WebResponseCode::BadRequest, "missing_enabled");
+					return;
+				}
+
+				WritableInputField& writable = writable_input_fields[static_cast<size_t>(writable_index)];
+				if (!writable.incoming_connection_handle)
+				{
+					write_error(WebResponseCode::Conflict, "writable_input_has_no_incoming_connection");
+					return;
+				}
+
+				const bool was_enabled = writable.incoming_connection_handle->is_enabled();
+				writable.incoming_connection_handle->set_enabled(update_payload.enabled);
+				if (was_enabled != update_payload.enabled)
+				{
+					ws_layout_dirty.set();
+					layout_cache_needs_rebuild = true;
+				}
+
+				UpdateResult& result = results[update_payload_index];
+				result.field_handle = writable_handle;
+				result.field_path = writable.path.c_str();
+				result.connection_handle = writable.incoming_connection_handle->handle_id;
+				result.enabled = writable.incoming_connection_handle->is_enabled();
+				result.status = "accepted";
+			}
 		}
 
 #if defined(ROBOTICK_PLATFORM_ESP32S3)
-		rebuild_layout_cache();
+		if (layout_cache_needs_rebuild)
+		{
+			rebuild_layout_cache();
+		}
+#else
+		(void)layout_cache_needs_rebuild;
 #endif
 
 		out_status_code = WebResponseCode::OK;
@@ -4218,8 +4254,11 @@ namespace robotick
 		char new_cached_layout_body[layout_cache_capacity] = {};
 		json::FixedBufferSink sink(new_cached_layout_body, layout_cache_capacity);
 		json::Writer<json::FixedBufferSink> writer(sink);
-		write_layout_json_stream(writer, *engine, session_id.c_str(), writable_input_fields);
-		writer.flush();
+		{
+			LockGuard writable_lock(writable_input_fields_mutex);
+			write_layout_json_stream(writer, *engine, session_id.c_str(), writable_input_fields);
+			writer.flush();
+		}
 
 		if (!sink.is_ok())
 		{
@@ -4276,8 +4315,11 @@ namespace robotick
 		last_known_writable_connection_handle_count = count_writable_input_connection_handles();
 		json::StringSink sink;
 		json::Writer<json::StringSink> writer(sink);
-		write_layout_json_stream(writer, *engine, session_id.c_str(), writable_input_fields);
-		writer.flush();
+		{
+			LockGuard writable_lock(writable_input_fields_mutex);
+			write_layout_json_stream(writer, *engine, session_id.c_str(), writable_input_fields);
+			writer.flush();
+		}
 		res.set_body(sink.c_str(), sink.size());
 #endif
 	}

--- a/cpp/tests/framework/Engine.test.cpp
+++ b/cpp/tests/framework/Engine.test.cpp
@@ -1501,7 +1501,7 @@ namespace robotick::test
 			peer_stop.set();
 		}
 
-		SECTION("Telemetry REST data-plane endpoints are removed")
+		SECTION("Telemetry REST layout endpoints remain available and stale gateway writes are rejected")
 		{
 			const uint16_t peer_port = choose_telemetry_port();
 			const uint16_t gateway_port = choose_telemetry_port();

--- a/cpp/tests/framework/Engine.test.cpp
+++ b/cpp/tests/framework/Engine.test.cpp
@@ -1015,6 +1015,108 @@ namespace robotick::test
 			stop_flag.set();
 		}
 
+		SECTION("Telemetry layout gives repeated dynamic struct instances distinct output types")
+		{
+			Model model;
+			const uint16_t telemetry_port = choose_telemetry_port();
+			model.set_telemetry_port(telemetry_port);
+			static const FieldConfigEntry config[] = {{"max_output_bytes", "64"}};
+			static const WorkloadSeed first_seed{TypeId("LargeDynamicWorkload"), StringView("first_dynamic"), 30.0f, {}, config, {}};
+			static const WorkloadSeed second_seed{TypeId("LargeDynamicWorkload"), StringView("second_dynamic"), 30.0f, {}, config, {}};
+			static const WorkloadSeed root_seed{TypeId("TickCounterWorkload"), StringView("dynamic_layout_root"), 30.0f, {}, {}, {}};
+			static const WorkloadSeed* const workloads[] = {&first_seed, &second_seed, &root_seed};
+			model.use_workload_seeds(workloads);
+			model.set_root_workload(root_seed);
+
+			Engine engine;
+			engine.load(model);
+			AtomicFlag stop_flag{false};
+			EngineRunThread runner(engine, stop_flag);
+			Thread::sleep_ms(100);
+
+			char url[256];
+			::snprintf(url, sizeof(url), "http://127.0.0.1:%u/api/telemetry/workloads_buffer/layout", static_cast<unsigned int>(telemetry_port));
+			const HttpResponse layout_response = http_request(url);
+			REQUIRE(layout_response.status_code == 200);
+
+			json::Document layout_document;
+			REQUIRE(layout_document.parse(layout_response.body.data));
+			const json::Value layout = layout_document.root();
+			REQUIRE(layout.contains("workloads"));
+			REQUIRE(layout.contains("types"));
+
+			auto find_named = [](const json::Value& array_value, const char* name)
+			{
+				json::Value found;
+				array_value.for_each_array(
+					[&](const json::Value item)
+					{
+						if (!found.is_valid() && item.contains("name") && item["name"].equals(name))
+						{
+							found = item;
+						}
+					});
+				return found;
+			};
+
+			auto find_field = [](const json::Value& type_value, const char* name)
+			{
+				json::Value found;
+				if (!type_value.contains("fields"))
+				{
+					return found;
+				}
+
+				type_value["fields"].for_each_array(
+					[&](const json::Value item)
+					{
+						if (!found.is_valid() && item.contains("name") && item["name"].equals(name))
+						{
+							found = item;
+						}
+					});
+				return found;
+			};
+
+			const json::Value first_workload = find_named(layout["workloads"], "first_dynamic");
+			const json::Value second_workload = find_named(layout["workloads"], "second_dynamic");
+			REQUIRE(first_workload.is_valid());
+			REQUIRE(second_workload.is_valid());
+			REQUIRE(first_workload.contains("outputs"));
+			REQUIRE(second_workload.contains("outputs"));
+			const char* first_outputs_type_name = first_workload["outputs"]["type"].get_c_string();
+			const char* second_outputs_type_name = second_workload["outputs"]["type"].get_c_string();
+			REQUIRE(first_outputs_type_name != nullptr);
+			REQUIRE(second_outputs_type_name != nullptr);
+			CHECK(!StringView(first_outputs_type_name).equals(second_outputs_type_name));
+
+			const json::Value first_outputs_type = find_named(layout["types"], first_outputs_type_name);
+			const json::Value second_outputs_type = find_named(layout["types"], second_outputs_type_name);
+			REQUIRE(first_outputs_type.is_valid());
+			REQUIRE(second_outputs_type.is_valid());
+			const json::Value first_bytes_field = find_field(first_outputs_type, "bytes");
+			const json::Value second_bytes_field = find_field(second_outputs_type, "bytes");
+			REQUIRE(first_bytes_field.is_valid());
+			REQUIRE(second_bytes_field.is_valid());
+			const char* first_dynamic_type_name = first_bytes_field["type"].get_c_string();
+			const char* second_dynamic_type_name = second_bytes_field["type"].get_c_string();
+			REQUIRE(first_dynamic_type_name != nullptr);
+			REQUIRE(second_dynamic_type_name != nullptr);
+			CHECK(!StringView(first_dynamic_type_name).equals(second_dynamic_type_name));
+
+			const json::Value first_dynamic_type = find_named(layout["types"], first_dynamic_type_name);
+			const json::Value second_dynamic_type = find_named(layout["types"], second_dynamic_type_name);
+			REQUIRE(first_dynamic_type.is_valid());
+			REQUIRE(second_dynamic_type.is_valid());
+			const json::Value first_data_buffer = find_field(first_dynamic_type, "data_buffer");
+			const json::Value second_data_buffer = find_field(second_dynamic_type, "data_buffer");
+			REQUIRE(first_data_buffer.is_valid());
+			REQUIRE(second_data_buffer.is_valid());
+			CHECK(first_data_buffer["offset_within_container"].get_int64() != second_data_buffer["offset_within_container"].get_int64());
+
+			stop_flag.set();
+		}
+
 		SECTION("WorkloadsBuffer is exact-sized after dynamic-struct preflight")
 		{
 			Model model;

--- a/cpp/tests/framework/Engine.test.cpp
+++ b/cpp/tests/framework/Engine.test.cpp
@@ -498,11 +498,7 @@ namespace robotick::test
 			return false;
 		}
 
-		bool wait_for_ws_frame_metadata_and_payload(
-			WsTestClient& client,
-			json::Document& metadata_doc,
-			size_t& payload_size,
-			int max_frames = 48)
+		bool wait_for_ws_frame_metadata_and_payload(WsTestClient& client, json::Document& metadata_doc, size_t& payload_size, int max_frames = 48)
 		{
 			WsFrame frame;
 			HeapVector<char> text;
@@ -1446,22 +1442,25 @@ namespace robotick::test
 			char url[256];
 			::snprintf(url, sizeof(url), "http://127.0.0.1:%u/api/telemetry/workloads_buffer/layout", static_cast<unsigned int>(gateway_port));
 			const HttpResponse local_layout = http_request(url);
-			REQUIRE(local_layout.status_code == 404);
+			REQUIRE(local_layout.status_code == 200);
+			REQUIRE(contains_text(local_layout.body.data, "\"writable_inputs\""));
 
 			::snprintf(url,
 				sizeof(url),
 				"http://127.0.0.1:%u/api/telemetry-gateway/peer-model/workloads_buffer/layout",
 				static_cast<unsigned int>(gateway_port));
 			const HttpResponse peer_layout = http_request(url);
-			REQUIRE(peer_layout.status_code == 404);
+			REQUIRE(peer_layout.status_code == 200);
+			REQUIRE(contains_text(peer_layout.body.data, "\"writable_inputs\""));
 
 			::snprintf(url,
 				sizeof(url),
 				"http://127.0.0.1:%u/api/telemetry-gateway/peer-model/set_workload_input_fields_data",
 				static_cast<unsigned int>(gateway_port));
-			const HttpResponse peer_write = http_request(
-				url, "POST", "{\"engine_session_id\":\"x\",\"writes\":[{\"field_handle\":1,\"value\":1.0}]}");
-			REQUIRE(peer_write.status_code == 404);
+			const HttpResponse peer_write =
+				http_request(url, "POST", "{\"engine_session_id\":\"x\",\"writes\":[{\"field_handle\":1,\"value\":1.0}]}");
+			REQUIRE(peer_write.status_code == 412);
+			REQUIRE(contains_text(peer_write.body.data, "\"field_path_required_for_stale_session_write\""));
 
 			gateway_stop.set();
 			peer_stop.set();

--- a/cpp/tests/framework/data/DataConnection.test.cpp
+++ b/cpp/tests/framework/data/DataConnection.test.cpp
@@ -173,6 +173,32 @@ namespace robotick::test
 			REQUIRE(b->inputs.y == Catch::Approx(3.14));
 		}
 
+		SECTION("Shared input handle suppresses and re-enables destination writes")
+		{
+			int source_value = 17;
+			int dest_value = 3;
+
+			DataConnectionInputHandle input_handle;
+			input_handle.dest_ptr = &dest_value;
+			input_handle.size = sizeof(dest_value);
+			input_handle.type = GET_TYPE_ID(int);
+			input_handle.set_enabled(false);
+
+			DataConnectionInfo connection;
+			connection.source_ptr = &source_value;
+			connection.dest_ptr = &dest_value;
+			connection.dest_handle = &input_handle;
+			connection.size = sizeof(source_value);
+			connection.type = GET_TYPE_ID(int);
+
+			connection.do_data_copy();
+			REQUIRE(dest_value == 3);
+
+			input_handle.set_enabled(true);
+			connection.do_data_copy();
+			REQUIRE(dest_value == 17);
+		}
+
 		SECTION("Resolves non-blackboard to blackboard")
 		{
 			Model model;

--- a/cpp/tests/framework/data/RemoteEngineConnection.test.cpp
+++ b/cpp/tests/framework/data/RemoteEngineConnection.test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "robotick/framework/data/RemoteEngineConnection.h"
+#include "robotick/framework/data/DataConnection.h"
 
 #include "robotick/api.h"
 #include "robotick/framework/concurrency/Thread.h"
@@ -13,6 +14,33 @@
 #include <catch2/catch_all.hpp>
 
 using namespace robotick;
+
+static void init_input_handle(DataConnectionInputHandle& handle, void* dest_ptr, size_t size, TypeId type)
+{
+	handle.dest_ptr = dest_ptr;
+	handle.size = size;
+	handle.type = type;
+	handle.set_enabled(true);
+}
+
+static void bind_receiver_field(
+	RemoteEngineConnection::Field& out, const char* path, DataConnectionInputHandle& input_handle, const TypeDescriptor* type_desc = nullptr)
+{
+	out.path = path;
+	out.size = input_handle.size;
+	out.type_desc = type_desc;
+	out.input_handle = &input_handle;
+}
+
+static RemoteEngineConnection::Field make_sender_field(const char* path, const void* send_ptr, size_t size, const TypeDescriptor* type_desc = nullptr)
+{
+	RemoteEngineConnection::Field field;
+	field.path = path;
+	field.send_ptr = send_ptr;
+	field.size = size;
+	field.type_desc = type_desc;
+	return field;
+}
 
 static int wait_for_listen_port(RemoteEngineConnection& receiver, int max_attempts = 50, int sleep_ms = 10)
 {
@@ -38,6 +66,8 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		static constexpr int target_value = 42;
 		int recv_value = 0;
 		int send_value = target_value;
+		DataConnectionInputHandle recv_handle;
+		init_input_handle(recv_handle, &recv_value, sizeof(recv_value), GET_TYPE_ID(int));
 
 		RemoteEngineConnection receiver;
 		RemoteEngineConnection sender;
@@ -48,10 +78,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 			{
 				if (string_equals(path, "x"))
 				{
-					out.path = path;
-					out.recv_ptr = &recv_value;
-					out.size = sizeof(int);
-					out.type_desc = TypeRegistry::get().find_by_name("int");
+					bind_receiver_field(out, path, recv_handle, TypeRegistry::get().find_by_name("int"));
 					return true;
 				}
 				return false;
@@ -61,7 +88,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		REQUIRE(receiver_listen_port > 0);
 
 		sender.configure_sender("test-sender", "test-receiver", "127.0.0.1", receiver_listen_port);
-		sender.register_field({"x", &send_value, nullptr, sizeof(int), 0});
+		sender.register_field(make_sender_field("x", &send_value, sizeof(int)));
 
 		for (int i = 0; i < 50; ++i)
 		{
@@ -76,12 +103,70 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		REQUIRE(recv_value == target_value);
 	}
 
+	SECTION("Receiver input handle suppresses remote writes until re-enabled", "[RemoteEngineConnection]")
+	{
+		int recv_value = 5;
+		int send_value = 42;
+
+		DataConnectionInputHandle input_handle;
+		init_input_handle(input_handle, &recv_value, sizeof(recv_value), GET_TYPE_ID(int));
+		input_handle.set_enabled(false);
+
+		RemoteEngineConnection receiver;
+		RemoteEngineConnection sender;
+
+		receiver.configure_receiver("test-receiver");
+		receiver.set_field_binder(
+			[&](const char* path, RemoteEngineConnection::Field& out)
+			{
+				if (string_equals(path, "x"))
+				{
+					bind_receiver_field(out, path, input_handle, TypeRegistry::get().find_by_name("int"));
+					return true;
+				}
+				return false;
+			});
+
+		const int receiver_listen_port = wait_for_listen_port(receiver);
+		REQUIRE(receiver_listen_port > 0);
+
+		sender.configure_sender("test-sender", "test-receiver", "127.0.0.1", receiver_listen_port);
+		sender.register_field(make_sender_field("x", &send_value, sizeof(int)));
+
+		for (int i = 0; i < 30; ++i)
+		{
+			sender.tick(robotick::TICK_INFO_FIRST_10MS_100HZ);
+			receiver.tick(robotick::TICK_INFO_FIRST_10MS_100HZ);
+			Thread::sleep_ms(20);
+		}
+		REQUIRE(recv_value == 5);
+
+		input_handle.set_enabled(true);
+		for (int i = 0; i < 30; ++i)
+		{
+			sender.tick(robotick::TICK_INFO_FIRST_10MS_100HZ);
+			receiver.tick(robotick::TICK_INFO_FIRST_10MS_100HZ);
+			Thread::sleep_ms(20);
+
+			if (recv_value == send_value)
+			{
+				break;
+			}
+		}
+
+		REQUIRE(recv_value == send_value);
+	}
+
 	SECTION("Handshake binds last field without trailing newline", "[RemoteEngineConnection]")
 	{
 		int recv_a = 0;
 		int recv_b = 0;
 		int send_a = 7;
 		int send_b = 9;
+		DataConnectionInputHandle recv_handle_a;
+		DataConnectionInputHandle recv_handle_b;
+		init_input_handle(recv_handle_a, &recv_a, sizeof(recv_a), GET_TYPE_ID(int));
+		init_input_handle(recv_handle_b, &recv_b, sizeof(recv_b), GET_TYPE_ID(int));
 
 		RemoteEngineConnection receiver;
 		RemoteEngineConnection sender;
@@ -97,19 +182,13 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 			{
 				if (string_equals(path, path_a))
 				{
-					out.path = path;
-					out.recv_ptr = &recv_a;
-					out.size = sizeof(int);
-					out.type_desc = TypeRegistry::get().find_by_name("int");
+					bind_receiver_field(out, path, recv_handle_a, TypeRegistry::get().find_by_name("int"));
 					++bind_count;
 					return true;
 				}
 				if (string_equals(path, path_b))
 				{
-					out.path = path;
-					out.recv_ptr = &recv_b;
-					out.size = sizeof(int);
-					out.type_desc = TypeRegistry::get().find_by_name("int");
+					bind_receiver_field(out, path, recv_handle_b, TypeRegistry::get().find_by_name("int"));
 					++bind_count;
 					return true;
 				}
@@ -120,8 +199,8 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		REQUIRE(receiver_listen_port > 0);
 
 		sender.configure_sender("test-sender", "test-receiver", "127.0.0.1", receiver_listen_port);
-		sender.register_field({path_a, &send_a, nullptr, sizeof(int), 0});
-		sender.register_field({path_b, &send_b, nullptr, sizeof(int), 0});
+		sender.register_field(make_sender_field(path_a, &send_a, sizeof(int)));
+		sender.register_field(make_sender_field(path_b, &send_b, sizeof(int)));
 
 		for (int i = 0; i < 50; ++i)
 		{
@@ -152,6 +231,8 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		int recv_val = 0;
 		int send_val = 123;
 		bool bound = false;
+		DataConnectionInputHandle recv_handle;
+		init_input_handle(recv_handle, &recv_val, sizeof(recv_val), GET_TYPE_ID(int));
 
 		RemoteEngineConnection receiver;
 		RemoteEngineConnection sender;
@@ -162,10 +243,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 			{
 				if (string_equals(path, long_path.c_str()))
 				{
-					out.path = path;
-					out.recv_ptr = &recv_val;
-					out.size = sizeof(int);
-					out.type_desc = TypeRegistry::get().find_by_name("int");
+					bind_receiver_field(out, path, recv_handle, TypeRegistry::get().find_by_name("int"));
 					bound = true;
 					return true;
 				}
@@ -176,7 +254,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		REQUIRE(receiver_listen_port > 0);
 
 		sender.configure_sender("tx", "rx", "127.0.0.1", receiver_listen_port);
-		sender.register_field({long_path.c_str(), &send_val, nullptr, sizeof(int), 0});
+		sender.register_field(make_sender_field(long_path.c_str(), &send_val, sizeof(int)));
 
 		for (int i = 0; i < 50; ++i)
 		{
@@ -196,6 +274,9 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		static constexpr int kFieldCount = 6;
 		int recv_values[kFieldCount] = {};
 		int send_values[kFieldCount] = {1, 2, 3, 4, 5, 6};
+		DataConnectionInputHandle recv_handles[kFieldCount];
+		for (int i = 0; i < kFieldCount; ++i)
+			init_input_handle(recv_handles[i], &recv_values[i], sizeof(recv_values[i]), GET_TYPE_ID(int));
 
 		FixedVector<FixedString64, kFieldCount> paths;
 		for (int i = 0; i < kFieldCount; ++i)
@@ -218,10 +299,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 				{
 					if (string_equals(paths[i].c_str(), path))
 					{
-						out.path = path;
-						out.recv_ptr = &recv_values[i];
-						out.size = sizeof(int);
-						out.type_desc = TypeRegistry::get().find_by_name("int");
+						bind_receiver_field(out, path, recv_handles[i], TypeRegistry::get().find_by_name("int"));
 						++bound_count;
 						return true;
 					}
@@ -235,7 +313,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		sender.configure_sender("tx", "rx", "127.0.0.1", receiver_listen_port);
 		for (int i = 0; i < kFieldCount; ++i)
 		{
-			sender.register_field({paths[i].c_str(), &send_values[i], nullptr, sizeof(int), 0});
+			sender.register_field(make_sender_field(paths[i].c_str(), &send_values[i], sizeof(int)));
 		}
 
 		for (int i = 0; i < 100; ++i)
@@ -266,9 +344,11 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		static constexpr int kFieldCount = 20;
 		int recv_values[kFieldCount] = {};
 		int send_values[kFieldCount] = {};
+		DataConnectionInputHandle recv_handles[kFieldCount];
 		for (int i = 0; i < kFieldCount; ++i)
 		{
 			send_values[i] = i + 100;
+			init_input_handle(recv_handles[i], &recv_values[i], sizeof(recv_values[i]), GET_TYPE_ID(int));
 		}
 
 		FixedVector<FixedString64, kFieldCount> paths;
@@ -292,10 +372,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 				{
 					if (string_equals(paths[i].c_str(), path))
 					{
-						out.path = path;
-						out.recv_ptr = &recv_values[i];
-						out.size = sizeof(int);
-						out.type_desc = TypeRegistry::get().find_by_name("int");
+						bind_receiver_field(out, path, recv_handles[i], TypeRegistry::get().find_by_name("int"));
 						++bound_count;
 						return true;
 					}
@@ -309,7 +386,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		sender.configure_sender("tx", "rx", "127.0.0.1", receiver_listen_port);
 		for (int i = 0; i < kFieldCount; ++i)
 		{
-			sender.register_field({paths[i].c_str(), &send_values[i], nullptr, sizeof(int), 0});
+			sender.register_field(make_sender_field(paths[i].c_str(), &send_values[i], sizeof(int)));
 		}
 
 		for (int i = 0; i < 150; ++i)
@@ -346,6 +423,8 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 			send_buffer[i] = target_value;
 		HeapVector<uint8_t> receive_buffer;
 		receive_buffer.initialize(32768);
+		DataConnectionInputHandle recv_handle;
+		init_input_handle(recv_handle, receive_buffer.data(), receive_buffer.size(), TypeId::invalid());
 
 		RemoteEngineConnection receiver;
 		RemoteEngineConnection sender;
@@ -354,9 +433,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		receiver.set_field_binder(
 			[&](const char*, RemoteEngineConnection::Field& out)
 			{
-				out.recv_ptr = receive_buffer.data();
-				out.size = receive_buffer.size();
-				out.path = "blob";
+				bind_receiver_field(out, "blob", recv_handle);
 				return true;
 			});
 
@@ -364,7 +441,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		REQUIRE(receiver_listen_port > 0);
 
 		sender.configure_sender("test-sender", "test-receiver", "127.0.0.1", receiver_listen_port);
-		sender.register_field({"blob", send_buffer.data(), nullptr, send_buffer.size(), 0});
+		sender.register_field(make_sender_field("blob", send_buffer.data(), send_buffer.size()));
 
 		for (int i = 0; i < 50; ++i)
 		{
@@ -402,6 +479,10 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		send_buffer.initialize(kBlobCapacity);
 		HeapVector<uint8_t> receive_buffer;
 		receive_buffer.initialize(kBlobCapacity);
+		DataConnectionInputHandle recv_count_handle;
+		DataConnectionInputHandle recv_blob_handle;
+		init_input_handle(recv_count_handle, &recv_count, sizeof(recv_count), GET_TYPE_ID(uint32_t));
+		init_input_handle(recv_blob_handle, receive_buffer.data(), receive_buffer.size(), TypeId::invalid());
 
 		RemoteEngineConnection receiver;
 		RemoteEngineConnection sender;
@@ -412,18 +493,13 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 			{
 				if (string_equals(path, "blob.count"))
 				{
-					out.recv_ptr = &recv_count;
-					out.size = sizeof(recv_count);
-					out.path = path;
-					out.type_desc = TypeRegistry::get().find_by_name("uint32_t");
+					bind_receiver_field(out, path, recv_count_handle, TypeRegistry::get().find_by_name("uint32_t"));
 					return true;
 				}
 
 				if (string_equals(path, "blob.data"))
 				{
-					out.recv_ptr = receive_buffer.data();
-					out.size = receive_buffer.size();
-					out.path = path;
+					bind_receiver_field(out, path, recv_blob_handle);
 					return true;
 				}
 
@@ -434,8 +510,8 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		REQUIRE(receiver_listen_port > 0);
 
 		sender.configure_sender("test-sender", "test-receiver", "127.0.0.1", receiver_listen_port);
-		sender.register_field({"blob.count", &send_count, nullptr, sizeof(send_count), 0});
-		sender.register_field({"blob.data", send_buffer.data(), nullptr, send_buffer.size(), 0});
+		sender.register_field(make_sender_field("blob.count", &send_count, sizeof(send_count)));
+		sender.register_field(make_sender_field("blob.data", send_buffer.data(), send_buffer.size()));
 
 		auto buffers_match = [&]() -> bool
 		{
@@ -490,6 +566,8 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		static constexpr int target_value_later = 200;
 		int recv_value = 0;
 		int send_value = target_value;
+		DataConnectionInputHandle recv_handle;
+		init_input_handle(recv_handle, &recv_value, sizeof(recv_value), GET_TYPE_ID(int));
 
 		RemoteEngineConnection receiver;
 		RemoteEngineConnection sender;
@@ -500,10 +578,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 			{
 				if (string_equals(path, "x"))
 				{
-					out.path = path;
-					out.recv_ptr = &recv_value;
-					out.size = sizeof(int);
-					out.type_desc = TypeRegistry::get().find_by_name("int");
+					bind_receiver_field(out, path, recv_handle, TypeRegistry::get().find_by_name("int"));
 					return true;
 				}
 				return false;
@@ -513,7 +588,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		REQUIRE(receiver_listen_port > 0);
 
 		sender.configure_sender("test-sender", "test-receiver", "127.0.0.1", receiver_listen_port);
-		sender.register_field({"x", &send_value, nullptr, sizeof(int), 0});
+		sender.register_field(make_sender_field("x", &send_value, sizeof(int)));
 
 		for (int i = 0; i < 50; ++i)
 		{
@@ -581,6 +656,8 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 	{
 		int recv_value = 0;
 		int send_value = 11;
+		DataConnectionInputHandle recv_handle;
+		init_input_handle(recv_handle, &recv_value, sizeof(recv_value), GET_TYPE_ID(int));
 
 		RemoteEngineConnection receiver;
 		RemoteEngineConnection sender;
@@ -589,10 +666,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		receiver.set_field_binder(
 			[&](const char*, RemoteEngineConnection::Field& f)
 			{
-				f.recv_ptr = &recv_value;
-				f.size = sizeof(int);
-				f.path = "x";
-				f.type_desc = TypeRegistry::get().find_by_name("int");
+				bind_receiver_field(f, "x", recv_handle, TypeRegistry::get().find_by_name("int"));
 				return true;
 			});
 
@@ -600,7 +674,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		REQUIRE(receiver_listen_port > 0);
 
 		sender.configure_sender("test-sender", "test-receiver", "127.0.0.1", receiver_listen_port);
-		sender.register_field({"x", &send_value, nullptr, sizeof(int), 0});
+		sender.register_field(make_sender_field("x", &send_value, sizeof(int)));
 
 		for (int i = 0; i < 200 && recv_value != 11; ++i)
 		{
@@ -628,6 +702,10 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 	{
 		int a_send = 101, a_recv = 0;
 		int b_send = 202, b_recv = 0;
+		DataConnectionInputHandle a_recv_handle;
+		DataConnectionInputHandle b_recv_handle;
+		init_input_handle(a_recv_handle, &a_recv, sizeof(a_recv), GET_TYPE_ID(int));
+		init_input_handle(b_recv_handle, &b_recv, sizeof(b_recv), GET_TYPE_ID(int));
 
 		RemoteEngineConnection a_rx, a_tx;
 		RemoteEngineConnection b_rx, b_tx;
@@ -639,10 +717,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 			{
 				if (string_equals(path, "value"))
 				{
-					f.path = path;
-					f.recv_ptr = &a_recv;
-					f.size = sizeof(int);
-					f.type_desc = TypeRegistry::get().find_by_name("int");
+					bind_receiver_field(f, path, a_recv_handle, TypeRegistry::get().find_by_name("int"));
 					return true;
 				}
 				return false;
@@ -658,10 +733,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 			{
 				if (string_equals(path, "value"))
 				{
-					f.path = path;
-					f.recv_ptr = &b_recv;
-					f.size = sizeof(int);
-					f.type_desc = TypeRegistry::get().find_by_name("int");
+					bind_receiver_field(f, path, b_recv_handle, TypeRegistry::get().find_by_name("int"));
 					return true;
 				}
 				return false;
@@ -671,10 +743,10 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		REQUIRE(b_rx_listen_port > 0);
 
 		a_tx.configure_sender("peer-a", "peer-b", "127.0.0.1", b_rx_listen_port);
-		a_tx.register_field({"value", &a_send, nullptr, sizeof(int), 0});
+		a_tx.register_field(make_sender_field("value", &a_send, sizeof(int)));
 
 		b_tx.configure_sender("peer-b", "peer-a", "127.0.0.1", a_rx_listen_port);
-		b_tx.register_field({"value", &b_send, nullptr, sizeof(int), 0});
+		b_tx.register_field(make_sender_field("value", &b_send, sizeof(int)));
 
 		for (int i = 0; i < 100; ++i)
 		{
@@ -698,6 +770,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 			const char* id;
 			int send_value = 0;
 			int recv_value = 0;
+			DataConnectionInputHandle recv_handle;
 
 			RemoteEngineConnection receiver;
 			RemoteEngineConnection sender;
@@ -706,10 +779,13 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		Peer a, b, c;
 		a.id = "peer-a";
 		a.send_value = 111;
+		init_input_handle(a.recv_handle, &a.recv_value, sizeof(a.recv_value), GET_TYPE_ID(int));
 		b.id = "peer-b";
 		b.send_value = 222;
+		init_input_handle(b.recv_handle, &b.recv_value, sizeof(b.recv_value), GET_TYPE_ID(int));
 		c.id = "peer-c";
 		c.send_value = 333;
+		init_input_handle(c.recv_handle, &c.recv_value, sizeof(c.recv_value), GET_TYPE_ID(int));
 
 		auto setup_receiver = [](Peer& peer, const char* expected_sender_id)
 		{
@@ -719,10 +795,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 				{
 					if (string_equals(path, expected_sender_id))
 					{
-						f.path = path;
-						f.recv_ptr = &peer.recv_value;
-						f.size = sizeof(int);
-						f.type_desc = TypeRegistry::get().find_by_name("int");
+						bind_receiver_field(f, path, peer.recv_handle, TypeRegistry::get().find_by_name("int"));
 						return true;
 					}
 					return false;
@@ -741,13 +814,13 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		REQUIRE(port_c > 0);
 
 		a.sender.configure_sender("peer-a", "peer-b", "127.0.0.1", port_b);
-		a.sender.register_field({"peer-a", &a.send_value, nullptr, sizeof(int), 0});
+		a.sender.register_field(make_sender_field("peer-a", &a.send_value, sizeof(int)));
 
 		b.sender.configure_sender("peer-b", "peer-c", "127.0.0.1", port_c);
-		b.sender.register_field({"peer-b", &b.send_value, nullptr, sizeof(int), 0});
+		b.sender.register_field(make_sender_field("peer-b", &b.send_value, sizeof(int)));
 
 		c.sender.configure_sender("peer-c", "peer-a", "127.0.0.1", port_a);
-		c.sender.register_field({"peer-c", &c.send_value, nullptr, sizeof(int), 0});
+		c.sender.register_field(make_sender_field("peer-c", &c.send_value, sizeof(int)));
 
 		for (int i = 0; i < 100; ++i)
 		{
@@ -777,6 +850,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 			const char* id;
 			int recv_value = 0;
 			int send_value = 0;
+			DataConnectionInputHandle recv_handle;
 			RemoteEngineConnection receiver;
 			RemoteEngineConnection sender;
 		};
@@ -784,9 +858,12 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		Peer a, b, c;
 		a.id = "peer-a";
 		a.send_value = 111;
+		init_input_handle(a.recv_handle, &a.recv_value, sizeof(a.recv_value), GET_TYPE_ID(int));
 		b.id = "peer-b";
+		init_input_handle(b.recv_handle, &b.recv_value, sizeof(b.recv_value), GET_TYPE_ID(int));
 		c.id = "peer-c";
 		c.send_value = 333;
+		init_input_handle(c.recv_handle, &c.recv_value, sizeof(c.recv_value), GET_TYPE_ID(int));
 
 		a.receiver.configure_receiver("peer-a");
 		a.receiver.set_field_binder(
@@ -794,10 +871,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 			{
 				if (string_equals(path, "peer-c"))
 				{
-					f.path = path;
-					f.recv_ptr = &a.recv_value;
-					f.size = sizeof(int);
-					f.type_desc = TypeRegistry::get().find_by_name("int");
+					bind_receiver_field(f, path, a.recv_handle, TypeRegistry::get().find_by_name("int"));
 					return true;
 				}
 				return false;
@@ -809,10 +883,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 			{
 				if (string_equals(path, "peer-a"))
 				{
-					f.path = path;
-					f.recv_ptr = &b.recv_value;
-					f.size = sizeof(int);
-					f.type_desc = TypeRegistry::get().find_by_name("int");
+					bind_receiver_field(f, path, b.recv_handle, TypeRegistry::get().find_by_name("int"));
 					return true;
 				}
 				return false;
@@ -824,10 +895,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 			{
 				if (string_equals(path, "peer-a"))
 				{
-					f.path = path;
-					f.recv_ptr = &c.recv_value;
-					f.size = sizeof(int);
-					f.type_desc = TypeRegistry::get().find_by_name("int");
+					bind_receiver_field(f, path, c.recv_handle, TypeRegistry::get().find_by_name("int"));
 					return true;
 				}
 				return false;
@@ -841,14 +909,14 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		REQUIRE(port_c > 0);
 
 		a.sender.configure_sender("peer-a", "peer-b", "127.0.0.1", port_b);
-		a.sender.register_field({"peer-a", &a.send_value, nullptr, sizeof(int), 0});
+		a.sender.register_field(make_sender_field("peer-a", &a.send_value, sizeof(int)));
 
 		RemoteEngineConnection a_to_c;
 		a_to_c.configure_sender("peer-a", "peer-c", "127.0.0.1", port_c);
-		a_to_c.register_field({"peer-a", &a.send_value, nullptr, sizeof(int), 0});
+		a_to_c.register_field(make_sender_field("peer-a", &a.send_value, sizeof(int)));
 
 		c.sender.configure_sender("peer-c", "peer-a", "127.0.0.1", port_a);
-		c.sender.register_field({"peer-c", &c.send_value, nullptr, sizeof(int), 0});
+		c.sender.register_field(make_sender_field("peer-c", &c.send_value, sizeof(int)));
 
 		for (int i = 0; i < 200; ++i)
 		{
@@ -885,6 +953,9 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 			int recv_from_b = 0;
 			int recv_from_c = 0;
 			int recv_from_d = 0;
+			DataConnectionInputHandle recv_handle_b;
+			DataConnectionInputHandle recv_handle_c;
+			DataConnectionInputHandle recv_handle_d;
 
 			RemoteEngineConnection rx_b;
 			RemoteEngineConnection rx_c;
@@ -901,28 +972,28 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 
 		Receiver a;
 		a.id = "peer-a";
+		init_input_handle(a.recv_handle_b, &a.recv_from_b, sizeof(a.recv_from_b), GET_TYPE_ID(int));
+		init_input_handle(a.recv_handle_c, &a.recv_from_c, sizeof(a.recv_from_c), GET_TYPE_ID(int));
+		init_input_handle(a.recv_handle_d, &a.recv_from_d, sizeof(a.recv_from_d), GET_TYPE_ID(int));
 
-		auto setup_receiver = [](RemoteEngineConnection& rx, const char* self, const char* sender_id, int* out)
+		auto setup_receiver = [](RemoteEngineConnection& rx, const char* self, const char* sender_id, DataConnectionInputHandle& input_handle)
 		{
 			rx.configure_receiver(self);
 			rx.set_field_binder(
-				[=](const char* path, RemoteEngineConnection::Field& f)
+				[&input_handle, sender_id](const char* path, RemoteEngineConnection::Field& f)
 				{
 					if (string_equals(path, sender_id))
 					{
-						f.path = path;
-						f.recv_ptr = out;
-						f.size = sizeof(int);
-						f.type_desc = TypeRegistry::get().find_by_name("int");
+						bind_receiver_field(f, path, input_handle, TypeRegistry::get().find_by_name("int"));
 						return true;
 					}
 					return false;
 				});
 		};
 
-		setup_receiver(a.rx_b, "peer-a", "peer-b", &a.recv_from_b);
-		setup_receiver(a.rx_c, "peer-a", "peer-c", &a.recv_from_c);
-		setup_receiver(a.rx_d, "peer-a", "peer-d", &a.recv_from_d);
+		setup_receiver(a.rx_b, "peer-a", "peer-b", a.recv_handle_b);
+		setup_receiver(a.rx_c, "peer-a", "peer-c", a.recv_handle_c);
+		setup_receiver(a.rx_d, "peer-a", "peer-d", a.recv_handle_d);
 
 		const int port_a_b = wait_for_listen_port(a.rx_b);
 		const int port_a_c = wait_for_listen_port(a.rx_c);
@@ -934,7 +1005,7 @@ TEST_CASE("Integration/Framework/Data/RemoteEngineConnection")
 		auto setup_sender = [](RemoteEngineConnection& s, const char* from, const char* to, const char* path, int* value, int port)
 		{
 			s.configure_sender(from, to, "127.0.0.1", port);
-			s.register_field({path, value, nullptr, sizeof(int), 0});
+			s.register_field(make_sender_field(path, value, sizeof(int)));
 		};
 
 		setup_sender(b.sender, "peer-b", "peer-a", "peer-b", &b.value, port_a_b);

--- a/cpp/tests/framework/data/RemoteEngineConnections.test.cpp
+++ b/cpp/tests/framework/data/RemoteEngineConnections.test.cpp
@@ -33,17 +33,23 @@ namespace robotick::test
 			Thread* sender_thread = nullptr;
 			Thread* receiver_thread = nullptr;
 
+			EngineRunThreadsGuard() = default;
+			EngineRunThreadsGuard(const EngineRunThreadsGuard&) = delete;
+			EngineRunThreadsGuard& operator=(const EngineRunThreadsGuard&) = delete;
+			EngineRunThreadsGuard(EngineRunThreadsGuard&&) = delete;
+			EngineRunThreadsGuard& operator=(EngineRunThreadsGuard&&) = delete;
+
 			~EngineRunThreadsGuard()
 			{
 				if (stop_flag)
 				{
 					stop_flag->set();
 				}
-				if (sender_thread && sender_thread->is_joining_supported())
+				if (sender_thread && sender_thread->is_joining_supported() && sender_thread->is_joinable())
 				{
 					sender_thread->join();
 				}
-				if (receiver_thread && receiver_thread->is_joining_supported())
+				if (receiver_thread && receiver_thread->is_joining_supported() && receiver_thread->is_joinable())
 				{
 					receiver_thread->join();
 				}
@@ -141,6 +147,20 @@ namespace robotick::test
 			for (int i = 0; i < attempts; ++i)
 			{
 				if (telemetry_raw_int_equals(telemetry_port, offset, expected))
+				{
+					return true;
+				}
+				Thread::sleep_ms(10);
+			}
+			return false;
+		}
+
+		bool wait_for_http_status(const char* url, long expected_status, int attempts)
+		{
+			for (int i = 0; i < attempts; ++i)
+			{
+				const HttpResponse response = http_request(url);
+				if (response.status_code == expected_status)
 				{
 					return true;
 				}
@@ -316,10 +336,23 @@ namespace robotick::test
 		AtomicFlag stop_flag(false);
 		AtomicFlag success_flag(false);
 
+		char receiver_layout_url[256];
+		::snprintf(receiver_layout_url,
+			sizeof(receiver_layout_url),
+			"http://127.0.0.1:%u/api/telemetry/workloads_buffer/layout",
+			static_cast<unsigned int>(receiver_telemetry_port));
+
 		// --- Threaded run
-		Thread sender_thread(engine_run_entry, new EngineRunContext{&sender, &stop_flag});
+		Thread sender_thread;
 		Thread receiver_thread(engine_run_entry, new EngineRunContext{&receiver, &stop_flag});
-		EngineRunThreadsGuard thread_guard{&stop_flag, &sender_thread, &receiver_thread};
+		EngineRunThreadsGuard thread_guard;
+		thread_guard.stop_flag = &stop_flag;
+		thread_guard.receiver_thread = &receiver_thread;
+
+		REQUIRE(wait_for_http_status(receiver_layout_url, 200, 100));
+
+		sender_thread = Thread(engine_run_entry, new EngineRunContext{&sender, &stop_flag});
+		thread_guard.sender_thread = &sender_thread;
 
 		// --- Watch for success or timeout
 		const auto start = Clock::now();
@@ -342,13 +375,7 @@ namespace robotick::test
 		REQUIRE(success_flag.is_set());
 
 		{
-			char layout_url[256];
-			::snprintf(
-				layout_url,
-				sizeof(layout_url),
-				"http://127.0.0.1:%u/api/telemetry/workloads_buffer/layout",
-				static_cast<unsigned int>(receiver_telemetry_port));
-			const HttpResponse layout = http_request(layout_url);
+			const HttpResponse layout = http_request(receiver_layout_url);
 			REQUIRE(layout.status_code == 200);
 			REQUIRE(contains_text(layout.body.data, "\"field_path\":\"receiver_workload.inputs.remote_x\""));
 			REQUIRE(contains_text(layout.body.data, "\"incoming_connection_handle\":"));

--- a/cpp/tests/framework/data/RemoteEngineConnections.test.cpp
+++ b/cpp/tests/framework/data/RemoteEngineConnections.test.cpp
@@ -11,6 +11,7 @@
 
 #include <arpa/inet.h>
 #include <catch2/catch_all.hpp>
+#include <curl/curl.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -24,6 +25,77 @@ namespace robotick::test
 			Engine* engine = nullptr;
 			AtomicFlag* stop_flag = nullptr;
 		};
+
+		struct HttpTextBuffer
+		{
+			char data[65536] = {};
+			size_t len = 0;
+
+			void append(const char* src, size_t count)
+			{
+				if (!src || count == 0)
+					return;
+				const size_t cap = sizeof(data) - 1;
+				const size_t room = len < cap ? cap - len : 0;
+				const size_t to_copy = room < count ? room : count;
+				if (to_copy > 0)
+				{
+					::memcpy(data + len, src, to_copy);
+					len += to_copy;
+					data[len] = '\0';
+				}
+			}
+		};
+
+		struct HttpResponse
+		{
+			long status_code = 0;
+			HttpTextBuffer body;
+		};
+
+		size_t curl_write_to_text(char* ptr, size_t size, size_t nmemb, void* userdata)
+		{
+			auto& out = *static_cast<HttpTextBuffer*>(userdata);
+			const size_t bytes = size * nmemb;
+			out.append(ptr, bytes);
+			return bytes;
+		}
+
+		HttpResponse http_request(const char* url, const char* method = "GET", const char* body = nullptr)
+		{
+			CURL* curl = curl_easy_init();
+			REQUIRE(curl != nullptr);
+
+			HttpResponse response;
+			curl_easy_setopt(curl, CURLOPT_URL, url);
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT, 2L);
+			curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_to_text);
+			curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response.body);
+			if (::strcmp(method, "POST") == 0)
+			{
+				curl_easy_setopt(curl, CURLOPT_POST, 1L);
+				curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body ? body : "");
+				curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, body ? static_cast<long>(::strlen(body)) : 0L);
+				struct curl_slist* headers = nullptr;
+				headers = curl_slist_append(headers, "Content-Type: application/json");
+				curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+				curl_easy_perform(curl);
+				curl_slist_free_all(headers);
+			}
+			else
+			{
+				curl_easy_perform(curl);
+			}
+
+			curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response.status_code);
+			curl_easy_cleanup(curl);
+			return response;
+		}
+
+		bool contains_text(const char* haystack, const char* needle)
+		{
+			return haystack && needle && ::strstr(haystack, needle) != nullptr;
+		}
 
 		constexpr long long kRemoteEngineConnectionTimeoutNs = 3'000'000'000LL;
 
@@ -209,6 +281,65 @@ namespace robotick::test
 			Thread::sleep_ms(10);
 		}
 
+		REQUIRE(success_flag.is_set());
+
+		{
+			char layout_url[256];
+			::snprintf(
+				layout_url,
+				sizeof(layout_url),
+				"http://127.0.0.1:%u/api/telemetry/workloads_buffer/layout",
+				static_cast<unsigned int>(receiver_telemetry_port));
+			const HttpResponse layout = http_request(layout_url);
+			REQUIRE(layout.status_code == 200);
+			REQUIRE(contains_text(layout.body.data, "\"field_path\":\"receiver_workload.inputs.remote_x\""));
+			REQUIRE(contains_text(layout.body.data, "\"incoming_connection_handle\":"));
+			REQUIRE(contains_text(layout.body.data, "\"incoming_connection_enabled\":true"));
+		}
+
+		{
+			char state_url[256];
+			::snprintf(
+				state_url,
+				sizeof(state_url),
+				"http://127.0.0.1:%u/api/telemetry/set_workload_input_connection_state",
+				static_cast<unsigned int>(receiver_telemetry_port));
+			const HttpResponse suppress = http_request(
+				state_url,
+				"POST",
+				"{\"updates\":[{\"field_path\":\"receiver_workload.inputs.remote_x\",\"enabled\":false}]}");
+			REQUIRE(suppress.status_code == 200);
+			REQUIRE(contains_text(suppress.body.data, "\"incoming_connection_enabled\":false"));
+
+			sender_workload->outputs.local_x = 456;
+			for (int i = 0; i < 40; ++i)
+			{
+				if (receiver_workload->inputs.remote_x != VALUE_TO_TRANSMIT)
+				{
+					break;
+				}
+				Thread::sleep_ms(10);
+			}
+			REQUIRE(receiver_workload->inputs.remote_x == VALUE_TO_TRANSMIT);
+
+			const HttpResponse reenable = http_request(
+				state_url,
+				"POST",
+				"{\"updates\":[{\"field_path\":\"receiver_workload.inputs.remote_x\",\"enabled\":true}]}");
+			REQUIRE(reenable.status_code == 200);
+			REQUIRE(contains_text(reenable.body.data, "\"incoming_connection_enabled\":true"));
+
+			for (int i = 0; i < 80; ++i)
+			{
+				if (receiver_workload->inputs.remote_x == 456)
+				{
+					break;
+				}
+				Thread::sleep_ms(10);
+			}
+			REQUIRE(receiver_workload->inputs.remote_x == 456);
+		}
+
 		stop_flag.set();
 
 		if (sender_thread.is_joining_supported())
@@ -216,8 +347,8 @@ namespace robotick::test
 		if (receiver_thread.is_joining_supported())
 			receiver_thread.join();
 
-		REQUIRE(sender_workload->outputs.local_x == VALUE_TO_TRANSMIT);
-		REQUIRE(receiver_workload->inputs.remote_x == VALUE_TO_TRANSMIT);
+		REQUIRE(sender_workload->outputs.local_x == 456);
+		REQUIRE(receiver_workload->inputs.remote_x == 456);
 
 		REQUIRE(success_flag.is_set());
 	}

--- a/cpp/tests/framework/data/RemoteEngineConnections.test.cpp
+++ b/cpp/tests/framework/data/RemoteEngineConnections.test.cpp
@@ -1,11 +1,12 @@
 // Copyright Robotick contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#include "robotick/framework/data/RemoteEngineConnections.h"
 #include "robotick/framework/Engine.h"
 #include "robotick/framework/concurrency/Atomic.h"
 #include "robotick/framework/concurrency/Thread.h"
+#include "robotick/framework/data/WorkloadsBuffer.h"
 #include "robotick/framework/model/DataConnectionSeed.h"
-#include "robotick/framework/data/RemoteEngineConnections.h"
 #include "robotick/framework/model/RemoteModelSeed.h"
 #include "robotick/framework/time/Clock.h"
 
@@ -24,6 +25,29 @@ namespace robotick::test
 		{
 			Engine* engine = nullptr;
 			AtomicFlag* stop_flag = nullptr;
+		};
+
+		struct EngineRunThreadsGuard
+		{
+			AtomicFlag* stop_flag = nullptr;
+			Thread* sender_thread = nullptr;
+			Thread* receiver_thread = nullptr;
+
+			~EngineRunThreadsGuard()
+			{
+				if (stop_flag)
+				{
+					stop_flag->set();
+				}
+				if (sender_thread && sender_thread->is_joining_supported())
+				{
+					sender_thread->join();
+				}
+				if (receiver_thread && receiver_thread->is_joining_supported())
+				{
+					receiver_thread->join();
+				}
+			}
 		};
 
 		struct HttpTextBuffer
@@ -95,6 +119,34 @@ namespace robotick::test
 		bool contains_text(const char* haystack, const char* needle)
 		{
 			return haystack && needle && ::strstr(haystack, needle) != nullptr;
+		}
+
+		bool telemetry_raw_int_equals(uint16_t telemetry_port, size_t offset, int expected)
+		{
+			char raw_url[256];
+			::snprintf(raw_url, sizeof(raw_url), "http://127.0.0.1:%u/api/telemetry/workloads_buffer/raw", static_cast<unsigned int>(telemetry_port));
+			const HttpResponse raw = http_request(raw_url);
+			if (raw.status_code != 200 || raw.body.len < offset + sizeof(int))
+			{
+				return false;
+			}
+
+			int actual = 0;
+			::memcpy(&actual, raw.body.data + offset, sizeof(actual));
+			return actual == expected;
+		}
+
+		bool wait_for_telemetry_raw_int(uint16_t telemetry_port, size_t offset, int expected, int attempts)
+		{
+			for (int i = 0; i < attempts; ++i)
+			{
+				if (telemetry_raw_int_equals(telemetry_port, offset, expected))
+				{
+					return true;
+				}
+				Thread::sleep_ms(10);
+			}
+			return false;
 		}
 
 		constexpr long long kRemoteEngineConnectionTimeoutNs = 3'000'000'000LL;
@@ -171,9 +223,11 @@ namespace robotick::test
 	struct RemoteInputs
 	{
 		int remote_x = 0;
+		int local_x = VALUE_TO_TRANSMIT;
 	};
 	ROBOTICK_REGISTER_STRUCT_BEGIN(RemoteInputs)
 	ROBOTICK_STRUCT_FIELD(RemoteInputs, int, remote_x)
+	ROBOTICK_STRUCT_FIELD(RemoteInputs, int, local_x)
 	ROBOTICK_REGISTER_STRUCT_END(RemoteInputs)
 
 	struct RemoteOutputs
@@ -189,7 +243,7 @@ namespace robotick::test
 		RemoteInputs inputs;
 		RemoteOutputs outputs;
 
-		void tick(const TickInfo&) {}
+		void tick(const TickInfo&) { outputs.local_x = inputs.local_x; }
 	};
 	ROBOTICK_REGISTER_WORKLOAD(TestRemoteWorkload, void, RemoteInputs, RemoteOutputs)
 
@@ -253,22 +307,26 @@ namespace robotick::test
 		sender.load(sender_model);
 		receiver.load(receiver_model);
 
+		auto* receiver_workload = receiver.find_instance<TestRemoteWorkload>("receiver_workload");
+		REQUIRE(receiver_workload != nullptr);
+		const uint8_t* receiver_buffer_base = receiver.get_workloads_buffer().raw_ptr();
+		const size_t receiver_remote_x_offset =
+			static_cast<size_t>(reinterpret_cast<const uint8_t*>(&receiver_workload->inputs.remote_x) - receiver_buffer_base);
+
 		AtomicFlag stop_flag(false);
 		AtomicFlag success_flag(false);
 
 		// --- Threaded run
 		Thread sender_thread(engine_run_entry, new EngineRunContext{&sender, &stop_flag});
 		Thread receiver_thread(engine_run_entry, new EngineRunContext{&receiver, &stop_flag});
+		EngineRunThreadsGuard thread_guard{&stop_flag, &sender_thread, &receiver_thread};
 
 		// --- Watch for success or timeout
-		auto* sender_workload = sender.find_instance<TestRemoteWorkload>("sender_workload");
-		auto* receiver_workload = receiver.find_instance<TestRemoteWorkload>("receiver_workload");
-
 		const auto start = Clock::now();
 
 		while (!stop_flag.is_set())
 		{
-			if (receiver_workload && sender_workload && receiver_workload->inputs.remote_x == sender_workload->outputs.local_x)
+			if (telemetry_raw_int_equals(receiver_telemetry_port, receiver_remote_x_offset, VALUE_TO_TRANSMIT))
 			{
 				success_flag.set();
 				break;
@@ -311,16 +369,21 @@ namespace robotick::test
 			REQUIRE(suppress.status_code == 200);
 			REQUIRE(contains_text(suppress.body.data, "\"incoming_connection_enabled\":false"));
 
-			sender_workload->outputs.local_x = 456;
-			for (int i = 0; i < 40; ++i)
+			char sender_write_url[256];
+			::snprintf(sender_write_url,
+				sizeof(sender_write_url),
+				"http://127.0.0.1:%u/api/telemetry/set_workload_input_fields_data",
+				static_cast<unsigned int>(sender_telemetry_port));
+			const HttpResponse sender_write =
+				http_request(sender_write_url, "POST", "{\"writes\":[{\"field_path\":\"sender_workload.inputs.local_x\",\"value\":456}]}");
+			REQUIRE(sender_write.status_code == 200);
+
+			for (int i = 0; i < 40 && !telemetry_raw_int_equals(receiver_telemetry_port, receiver_remote_x_offset, 456); ++i)
 			{
-				if (receiver_workload->inputs.remote_x != VALUE_TO_TRANSMIT)
-				{
-					break;
-				}
 				Thread::sleep_ms(10);
 			}
-			REQUIRE(receiver_workload->inputs.remote_x == VALUE_TO_TRANSMIT);
+			REQUIRE_FALSE(telemetry_raw_int_equals(receiver_telemetry_port, receiver_remote_x_offset, 456));
+			REQUIRE(telemetry_raw_int_equals(receiver_telemetry_port, receiver_remote_x_offset, VALUE_TO_TRANSMIT));
 
 			const HttpResponse reenable = http_request(
 				state_url,
@@ -329,26 +392,8 @@ namespace robotick::test
 			REQUIRE(reenable.status_code == 200);
 			REQUIRE(contains_text(reenable.body.data, "\"incoming_connection_enabled\":true"));
 
-			for (int i = 0; i < 80; ++i)
-			{
-				if (receiver_workload->inputs.remote_x == 456)
-				{
-					break;
-				}
-				Thread::sleep_ms(10);
-			}
-			REQUIRE(receiver_workload->inputs.remote_x == 456);
+			REQUIRE(wait_for_telemetry_raw_int(receiver_telemetry_port, receiver_remote_x_offset, 456, 80));
 		}
-
-		stop_flag.set();
-
-		if (sender_thread.is_joining_supported())
-			sender_thread.join();
-		if (receiver_thread.is_joining_supported())
-			receiver_thread.join();
-
-		REQUIRE(sender_workload->outputs.local_x == 456);
-		REQUIRE(receiver_workload->inputs.remote_x == 456);
 
 		REQUIRE(success_flag.is_set());
 	}

--- a/docs/design/26-04-18 - operator_control_and_connection_suppression.md
+++ b/docs/design/26-04-18 - operator_control_and_connection_suppression.md
@@ -1,0 +1,178 @@
+# Operator Control And Connection Suppression
+
+_Written 18th April 2026_
+
+## Why This Note Exists
+
+Studio operator control has moved from a dedicated robot-side RC model toward a
+more general live-control surface.
+
+The important shift is that Studio no longer needs special RC workloads to
+temporarily override a connected input. Instead, it can suppress the incoming
+data-connection for a real destination field, write that field directly, and
+then release suppression so normal engine or REC control resumes.
+
+This is worth naming because it is now a reusable Robotick/Studio pattern, not a
+Barr.e-specific RC feature.
+
+## Design Rules
+
+The durable rules are:
+
+- operator mappings live Studio-side, normally in `overlay/remote-controls`
+- Studio writes true destination input fields, not RC proxy fields
+- connected input suppression means "stop incoming data-connections writing this"
+- suppression does not mean Studio permanently owns the field
+- releasing suppression restores ordinary engine/REC-driven behavior
+- unconnected fields do not need special suppression behavior
+
+## The Pattern In One Sentence
+
+Studio temporarily gates incoming data-connections at the destination input
+handle, writes the real input field directly, and later re-enables the normal
+connection path.
+
+## Runtime Primitive
+
+The engine-side primitive is `DataConnectionInputHandle`.
+
+Each handle represents an incoming connected destination input/path. Local
+data-connections and REC receiver writes both route their final destination copy
+through that same handle.
+
+The handle carries:
+
+- destination path / field info
+- destination memory and size
+- an enabled flag for incoming data-connection writes
+- copy helpers used by both local connections and REC
+
+The semantic split is deliberately small:
+
+- handle enabled: local/REC connection writes are allowed
+- handle suppressed: local/REC connection writes are ignored
+- telemetry writes are unaffected and may still write the field directly
+
+This keeps suppression generic. It is not RC-specific, and it is not a Studio
+ownership system.
+
+## Tick-Time Consequence
+
+The engine still sees a normal input field.
+
+The difference is only whether incoming data-connections are allowed to perform
+their final write for that destination. Once the connection writer reaches the
+shared handle, the handle decides whether to copy or ignore the incoming value.
+
+Studio telemetry writes remain ordinary input writes. They do not need a second
+special override channel.
+
+## Studio Field UX
+
+Studio exposes suppression as field state:
+
+- active connected fields show active connection chrome
+- suppressed connected fields show suppressed connection chrome
+- a field-level lightning control can suppress or re-enable the connection
+- editing a connected field auto-suppresses before committing the write
+- focus alone does not suppress
+
+This gives the operator a clear visual answer to:
+
+- is this field normally connected?
+- is the connection currently allowed to drive it?
+- am I currently overriding it from Studio?
+
+## Studio Remote-Controls
+
+`overlay/remote-controls` is now the preferred home for operator puppeteering.
+
+The config describes:
+
+- what each stick controls
+- named modes for each stick
+- per-mode dead-zone, transform, and scale
+- the exact destination fields written by each mode
+- button-to-field mappings
+
+Selected stick modes suppress their connected destination fields before writing,
+and reassert suppression as writes continue. When a mode is deselected or the
+panel releases control, Studio re-enables those incoming connections.
+
+Button writes can use the same direct-field model. For example, Barr.e's blink
+button now targets the face model's real blink input rather than an RC proxy
+field.
+
+## Naming Convention
+
+Mode names should describe operator intent, not the implementation detail.
+
+Preferred examples:
+
+- `locomotion` rather than `drive_wheels`
+- `camera_orbit` rather than `chase_camera`
+- `look_direction_eyes` for eye/gaze offset control
+- `look_direction_head` for head/yaw-pitch amount control
+
+This keeps config readable if the robot implementation changes.
+
+## Launcher Semantics
+
+The launcher should treat per-model play/restart consistently with the main
+launcher controls.
+
+Current rule:
+
+- main profile run/restart performs the normal generate/build/deploy/run flow
+- per-model play/restart should also use the full per-model run pipeline
+- per-model stop remains a single-model stop
+
+This matters because YAML/model/config changes often affect generated or
+compiled output. A relaunch-only path can leave stale binaries running.
+
+## Current Robot Shape
+
+Barr.e, Alf.e, and Pip.e no longer need dedicated RC models for normal Studio
+operator control.
+
+Current direction:
+
+- `robots/*/*.rc.yaml` holds Studio-side operator mappings
+- real robot models own the actual behavior fields
+- Studio writes those true destination fields
+- connection suppression handles temporary operator override
+- the legacy core `RemoteControlWorkload` remains available as an example or
+  generic gamepad normalizer, but it is not the preferred puppeteering path
+
+## Barr.e Example
+
+Barr.e currently follows this pattern:
+
+- left stick locomotion writes spine drive inputs
+- right stick camera orbit writes simulator camera orbit inputs
+- right stick look-direction modes write real face/spine expression inputs
+- blink writes the face model's real `blink_request` input
+- the former RC/mind toggle workload has been removed
+- brain expressive outputs connect directly to spine and face remote inputs
+
+The operator no longer takes control by switching Barr.e into a robot-side RC
+mode. Studio temporarily suppresses the relevant incoming connections and writes
+the destination fields directly.
+
+## Practical Rule Of Thumb
+
+If a control is about live operator puppeteering or tuning, prefer:
+
+- Studio config
+- true destination fields
+- connection suppression for connected inputs
+
+If a control is about autonomous robot behavior, prefer:
+
+- normal model workloads
+- local or REC data-connections
+- telemetry only for observation and occasional tuning
+
+That keeps the robot model honest: it defines behavior, while Studio defines the
+operator surface used to puppeteer or adjust that behavior live.
+

--- a/docs/design/26-04-18 - operator_control_and_connection_suppression.md
+++ b/docs/design/26-04-18 - operator_control_and_connection_suppression.md
@@ -175,4 +175,3 @@ If a control is about autonomous robot behavior, prefer:
 
 That keeps the robot model honest: it defines behavior, while Studio defines the
 operator surface used to puppeteer or adjust that behavior live.
-

--- a/docs/design/26-04-18 - operator_control_and_connection_suppression.md
+++ b/docs/design/26-04-18 - operator_control_and_connection_suppression.md
@@ -118,6 +118,10 @@ This keeps config readable if the robot implementation changes.
 
 ## Launcher Semantics
 
+Connection suppression depends on the same generated model metadata and writable
+input layout that Studio exposes for operator control, so launcher behavior needs
+to keep those artifacts in step with the running model process.
+
 The launcher should treat per-model play/restart consistently with the main
 launcher controls.
 


### PR DESCRIPTION
## Summary

- Adds `DataConnectionInputHandle` as the shared destination-side gate for incoming local data-connections and REC receiver writes.
- Registers input handles in `Engine` by path, destination pointer, and handle id so telemetry can identify connected writable inputs.
- Routes local data-connection copies and remote-engine receiver copies through the input handle, allowing enabled/suppressed state to decide whether incoming data is applied.
- Extends telemetry layout/input write responses with incoming-connection handle/path/enabled metadata and adds `POST /api/telemetry/set_workload_input_connection_state` for suppressing or re-enabling connected inputs.
- Covers the operator-control pattern in a design note and adds unit/integration coverage for suppression, REC delivery, telemetry state changes, and dynamic-buffer offset communication.

## Testing

- `cmake --preset robotick-engine-tests-linux-debug`
- `cmake --build --preset robotick-engine-tests-linux-debug`
- `ctest --test-dir build/robotick-engine-tests-linux-debug/cpp/tests --output-on-failure`